### PR TITLE
Fix specrange return type to be `Float64`

### DIFF
--- a/src/specrad.jl
+++ b/src/specrad.jl
@@ -81,7 +81,7 @@ function specrange(H, method::Val{:arnoldi}; kwargs...)
         E_min = 2 * E_min - real(R[2])
         E_max = 2 * E_max - real(R[end-1])
     end
-    return E_min, E_max
+    return E_min::Float64, E_max::Float64
 end
 
 
@@ -95,8 +95,9 @@ smallest and largest eigenvalue. This should only be used for relatively small
 matrices.
 """
 function specrange(H, method::Val{:diag}; kwargs...)
-    evals = eigvals(Array(H))
-    return evals[1], evals[end]
+    evals = real.(eigvals(Array(H)))
+    # "By default, the eigenvalues [...] are sorted [...] by (real(λ),imag(λ))"
+    return evals[1]::Float64, evals[end]::Float64
 end
 
 

--- a/test/test_specrad.jl
+++ b/test/test_specrad.jl
@@ -85,6 +85,8 @@ end
 
     prec = 1e-4
     E_min, E_max = specrange(H, method=:arnoldi, prec=prec)
+    @test E_min isa Float64
+    @test E_max isa Float64
     SHOWVALS && @show E_min, E_max
 
     Δ = evals[end] - evals[1]
@@ -94,5 +96,12 @@ end
     SHOWVALS && @show δmin, δmax
     @test evals[1] - 0.05 * Δ <= E_min <= evals[1]
     @test evals[end] <= E_max < evals[end] + 0.05 * Δ
+
+    E_min, E_max = specrange(H, method=:diag)
+    @test E_min isa Float64
+    @test E_max isa Float64
+    SHOWVALS && @show E_min, E_max
+    @test abs(evals[1] - E_min) < 1e-12
+    @test abs(evals[end] - E_max) < 1e-12
 
 end


### PR DESCRIPTION
By definition (according to the documentation, the `specrange` is on the real axis, and the returned values should be `Float64`. In particular, we should not return complex numbers.