### PR TITLE
Fix `axpy!` incompatibility with Julia 1.9

### DIFF
--- a/src/controls.jl
+++ b/src/controls.jl
@@ -1,6 +1,6 @@
 module Controls
 
-using LinearAlgebra.BLAS: axpy!
+using LinearAlgebra: axpy!
 
 export discretize, discretize_on_midpoints
 export get_control_parameters, getcontrols


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/issues/46658