### PR TITLE
Refactor for explicitly time-dependent generators

### DIFF
--- a/src/controls.jl
+++ b/src/controls.jl
@@ -223,7 +223,9 @@ replaces the time-dependent controls in `generator` with the values in
 The `vals_dict` is a dictionary (`IdDict`) mapping controls as returned by
 `getcontrols(generator)` to values.
 """
-function evalcontrols(generator::Tuple, vals_dict::AbstractDict)
+function evalcontrols(generator::Tuple, vals_dict::AbstractDict, _...)
+    # TODO: update documentation about possibility of additional parameters
+    # (`tlist`, `n`) or `t`. See usage in Krotov/GRAPE
     if isa(generator[1], Tuple)
         control = generator[1][2]
         G = vals_dict[control] * generator[1][1]
@@ -241,7 +243,7 @@ function evalcontrols(generator::Tuple, vals_dict::AbstractDict)
     return G
 end
 
-function evalcontrols(operator::AbstractMatrix, vals_dict::AbstractDict)
+function evalcontrols(operator::AbstractMatrix, _...)
     return operator
 end
 
@@ -254,7 +256,8 @@ evalcontrols!(G, generator, vals_dict)
 
 acts as [`evalcontrols`](@ref), but modifies `G` in-place.
 """
-function evalcontrols!(G, generator::Tuple, vals_dict::AbstractDict)
+function evalcontrols!(G, generator::Tuple, vals_dict::AbstractDict, _...)
+    # TODO: update documentation about additonal parameters, see evalcontrols
     if generator[1] isa Tuple
         control = generator[1][2]
         axpy!(vals_dict[control], generator[1][1], G)
@@ -272,7 +275,7 @@ function evalcontrols!(G, generator::Tuple, vals_dict::AbstractDict)
     return G
 end
 
-function evalcontrols!(G, operator::AbstractMatrix, vals_dict::AbstractDict)
+function evalcontrols!(G, operator::AbstractMatrix, _...)
     copyto!(G, operator)
 end
 
@@ -376,7 +379,8 @@ function getcontrolderiv(generator::Tuple, control)
     if isnothing(control_generator)
         return nothing
     else
-        return v -> control_generator
+        # TODO: document additional parameters, see evalcontrols
+        return (v, _...) -> control_generator
     end
 end
 

--- a/src/pwc_utils.jl
+++ b/src/pwc_utils.jl
@@ -63,22 +63,28 @@ end
 
 function _pwc_get_max_genop(generator, controls, tlist)
     controlvals = [Controls.discretize(control, tlist) for control in controls]
+    # TODO: this does not take into account explicit time dependencies (control
+    # amplitude ≠ control function). For now, we just take any explicit time
+    # dependency in the middle of the time grid.
+    n = length(tlist) ÷ 2
     max_vals =
         IdDict(control => maximum(controlvals[i]) for (i, control) in enumerate(controls))
-    return Controls.evalcontrols(generator, max_vals)
+    return Controls.evalcontrols(generator, max_vals, tlist, n)
 end
 
 
 function _pwc_set_genop!(propagator::PiecewisePropagator, n)
     vals_dict = IdDict(c => propagator.parameters[c][n] for c in propagator.controls)
     generator = getfield(propagator, :generator)
-    Controls.evalcontrols!(propagator.genop, generator, vals_dict)
+    tlist = propagator.tlist
+    Controls.evalcontrols!(propagator.genop, generator, vals_dict, tlist, n)
 end
 
 function _pwc_get_genop(propagator::PiecewisePropagator, n)
     vals_dict = IdDict(c => propagator.parameters[c][n] for c in propagator.controls)
     generator = getfield(propagator, :generator)
-    Controls.evalcontrols(generator, vals_dict)
+    tlist = propagator.tlist
+    Controls.evalcontrols(generator, vals_dict, tlist, n)
 end
 
 


### PR DESCRIPTION
In the future, we may want to allow for dynamic generators (Hamiltonians, Liouvillians) that have an explicit time-dependency. That is, the time dependency is not just in the controls. To support this, various functions in `QuantumPropagators.Controls`, e.g. `evalcontrols`, should accept additional arguments to specify the time at which the generator is being evaluated.

Currently, these additional arguments are not used and remain undocumented.