### PR TITLE
Add submodules `Amplitudes`, `Controls`, `Shapes`

### DIFF
--- a/docs/generate_api.jl
+++ b/docs/generate_api.jl
@@ -59,7 +59,7 @@ The highest-level API of the `QuantumPropagators.jl` package consists of a singl
 
 * [`propagate`](@ref) — Propagate a quantum state over an entire time grid under a given generator
 
-At a slightly lower level, propagation of quantum states in encapsulated by [The Propagator Interface](@ref):
+At a slightly lower level, propagation of quantum states in encapsulated by [The Propagator interface](@ref):
 
 * [`initprop`](@ref) — Initialize a `propagator` object, which is of some concrete (method-dependent) sub-type of [`AbstractPropagator`](@ref QuantumPropagators.AbstractPropagator)
 * [`reinitprop!`](@ref) — Re-initialize the `propagator`
@@ -84,6 +84,9 @@ The above list of methods constitutes the entire *public* interface of `QuantumP
 The full list of sub-modules is
 
 * [`QuantumPropagators.Generators`](@ref QuantumPropagatorsGeneratorsAPI)
+* [`QuantumPropagators.Shapes`](@ref QuantumPropagatorsShapesAPI)
+* [`QuantumPropagators.Controls`](@ref QuantumPropagatorsControlsAPI)
+* [`QuantumPropagators.Amplitudes`](@ref QuantumPropagatorsAmplitudesAPI)
 * [`QuantumPropagators.Storage`](@ref QuantumPropagatorsStorageAPI)
 * [`QuantumPropagators.Cheby`](@ref QuantumPropagatorsChebyAPI)
 * [`QuantumPropagators.Newton`](@ref QuantumPropagatorsNewtonAPI)
@@ -186,6 +189,28 @@ open(outfile, "w") do out
         methods that define how these generators contain controls and control
         amplitudes. These methods must be defined for any custom generator or
         control amplitude.
+        """
+    )
+    write_module_api(
+        out,
+        QuantumPropagators.Shapes,
+        """The following routines define useful functin ``S(t)`` that can be
+        used for control functions or amplitudes.
+        """
+    )
+    write_module_api(
+        out,
+        QuantumPropagators.Controls,
+        """The following routines define method that must be defined for any
+        control function, or for generators with respect to control functions.
+        """
+    )
+    write_module_api(
+        out,
+        QuantumPropagators.Amplitudes,
+        raw"""The following types define control amplitudes
+        ``a(\{ϵ_l(t)\}, t)`` that depend on one or more control functions
+        ``ϵ_l(t)``.
         """
     )
     write_module_api(

--- a/docs/src/generators.md
+++ b/docs/src/generators.md
@@ -18,10 +18,13 @@ where ``L`` is the Liouvillian up to a factor of ``i``, see [`liouvillian`](@ref
 
 While the generator may have an explicit time dependency, in the context of optimal control the time dependency will usually be implicit in a dependency of the generator on one or more control functions. That is, ``Ĥ(t) = Ĥ(\{ϵ_l(t)\}, t)``. Any object passed to [`propagate`](@ref) as a `generator` must implement the following methods:
 
-* [`QuantumPropagators.Generators.getcontrols`](@ref) — extract the controls ``\{ϵ_l(t)\}`` from ``Ĥ(\{ϵ_l(t)\}, t)``
-* [`QuantumPropagators.Generators.evalcontrols`](@ref), [`QuantumPropagators.Generators.evalcontrols!`](@ref) — plug in values for the controls as well as any explicit time dependency to produce a static operator from the time-dependent generator
-* [`QuantumPropagators.Generators.substitute_controls`](@ref)  — replace the controls with different (e.g., optimized) controls, producing a new time-dependent generator
-* [`QuantumPropagators.Generators.getcontrolderiv`](@ref) — return ``\frac{∂ Ĥ(\{ϵ_{l'}(t)\}, t)}{∂ ϵ_l(t)}``. The result may be `nothing` if ``Ĥ(t)`` does not depend on the particular ``ϵ_l(t)``, a static operator if ``Ĥ(t)`` is linear in the control ``ϵ_l(t)`` and has no explicit time dependency, or a new time-dependent generator to be evaluated via [`evalcontrols`](@ref QuantumPropagators.Generators.evalcontrols) otherwise.
+* [`QuantumPropagators.Controls.getcontrols`](@ref) — extract the controls ``\{ϵ_l(t)\}`` from ``Ĥ(\{ϵ_l(t)\}, t)``
+* [`QuantumPropagators.Controls.evalcontrols`](@ref), [`QuantumPropagators.Controls.evalcontrols!`](@ref) — plug in values for the controls as well as any explicit time dependency to produce a static operator from the time-dependent generator
+* [`QuantumPropagators.Controls.substitute_controls`](@ref)  — replace the controls with different (e.g., optimized) controls, producing a new time-dependent generator
+
+```raw COMMENT
+* [`QuantumPropagators.Controls.getcontrolderiv`](@ref) — return ``\frac{∂ Ĥ(\{ϵ_{l'}(t)\}, t)}{∂ ϵ_l(t)}``. The result may be `nothing` if ``Ĥ(t)`` does not depend on the particular ``ϵ_l(t)``, a static operator if ``Ĥ(t)`` is linear in the control ``ϵ_l(t)`` and has no explicit time dependency, or a new time-dependent generator to be evaluated via [`evalcontrols`](@ref QuantumPropagators.Generators.evalcontrols) otherwise.
+```
 
 When writing a custom generator type, the [`QuantumPropagators.Generators.check_generator`](@ref) routine should be used to check that all of these methods are implemented.
 
@@ -39,20 +42,23 @@ that is, an (optional) drift term ``Ĥ₀`` and an arbitrary number of control 
 
 In the form represented by a [`Generator`](@ref QuantumPropagators.Generators.Generator), the time-dependence of the control terms is via control amplitudes ``a_l(\{ϵ_{l'}(t)\}, t)``, which may depend on one or more control function ``\{ϵ_{l'}(t)\}``. In most cases, ``a_l(t) ≡ ϵ_l(t)``. Any other dependency of the control amplitudes on the control functions must be implemented via a custom type, for which the following methods must be defined:
 
-* [`QuantumPropagators.Generators.getcontrols`](@ref)
-* [`QuantumPropagators.Generators.evalcontrols`](@ref)
-* [`QuantumPropagators.Generators.substitute_controls`](@ref)
-* [`QuantumPropagators.Generators.getcontrolderiv`](@ref)
+* [`QuantumPropagators.Controls.getcontrols`](@ref)
+* [`QuantumPropagators.Controls.evalcontrols`](@ref)
+* [`QuantumPropagators.Controls.substitute_controls`](@ref)
 
-These are similar to the equivalent methods for a custom generator. However, [`QuantumPropagators.Generators.evalcontrols`](@ref) for an amplitude returns a number, not an operator. Also, [`QuantumPropagators.Generators.getcontrolderiv`](@ref) returns `0.0` if the control amplitude does not depend on a particular control function, instead of `nothing`.
+These are similar to the equivalent methods for a custom generator. However, [`QuantumPropagators.Controls.evalcontrols`](@ref) for an amplitude returns a number, not an operator.
+
+```raw COMMENT
+Also, [`QuantumPropagators.Controls.getcontrolderiv`](@ref) returns `0.0` if the control amplitude does not depend on a particular control function, instead of `nothing`.
+```
 
 Any custom amplitude implementation should be checked with [`QuantumPropagators.Generators.check_amplitude`](@ref)
 
 
 ## Operators
 
-The [`QuantumPropagators.Generators.evalcontrols`](@ref) method applied to a generator returns a static operator. For any operator object the 5-argument [`LinearAlgebra.mul!`](https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.mul!) must be implemented to apply the operator to a state.
+The [`QuantumPropagators.Controls.evalcontrols`](@ref) method applied to a generator returns a static operator. For any operator object the 5-argument [`LinearAlgebra.mul!`](https://docs.julialang.org/en/v1/stdlib/LinearAlgebra/#LinearAlgebra.mul!) must be implemented to apply the operator to a state.
 
-For a [`Generator`](@ref) instance obtained from [`hamiltonian`](@ref) or [`liouvillian`](@ref), the resulting operator will be an [`Operator`](@ref QuantumPropagators.Generators.Operator) instance. Any custom type intended as an operator should use [`QuantumPropagators.Generators.check_operator`](@ref) to verify the implementation.
+For a [`Generator`](@ref QuantumPropagators.Generators.Generator) instance obtained from [`hamiltonian`](@ref) or [`liouvillian`](@ref), the resulting operator will be an [`Operator`](@ref QuantumPropagators.Generators.Operator) instance. Any custom type intended as an operator should use [`QuantumPropagators.Generators.check_operator`](@ref) to verify the implementation.
 
 In practice, an operator might also be used as a generator (for a propagation without any time dependency). For any custom operator type that should support this, the implementation should also be checked with [`QuantumPropagators.Generators.check_generator`](@ref).

--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -23,4 +23,4 @@
 
   Note the `method::Val{:mynewmethod}` as the fourth positional parameter. While the *public* interface for [`initprop`](@ref) takes `method` as a keyword argument, privately [`initprop`](@ref) dispatches for different methods as above.
 
-* Implement the remaining methods in [The Propagator Interface](@ref)
+* Implement the remaining methods in [The Propagator interface](@ref)

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -149,7 +149,7 @@ The `QuantumPropagators` API is structured similarly to the [DifferentialEquatio
 
 * The [`reinitprop!`](@ref) function is similar to [`DifferentialEquations.reinit!`](https://diffeq.sciml.ai/stable/basics/integrator/#SciMLBase.reinit!)
 
-* [The Propagator Interface](@ref) is similar to DifferentialEquations' [Integrator Interface](https://diffeq.sciml.ai/stable/basics/integrator/)
+* [The Propagator interface](@ref) is similar to DifferentialEquations' [Integrator Interface](https://diffeq.sciml.ai/stable/basics/integrator/)
 
 * [`propstep!`](@ref) corresponds to [`DifferentialEquations.step!`](https://diffeq.sciml.ai/stable/basics/integrator/#SciMLBase.step!)
 

--- a/src/QuantumPropagators.jl
+++ b/src/QuantumPropagators.jl
@@ -11,7 +11,14 @@ include("./storage.jl")   # submodule Storage
 using .Storage
 export init_storage, write_to_storage!, get_from_storage!
 
+include("./shapes.jl")  # submodule Shapes
+
+include("./controls.jl")  # submodule Controls
+
+include("./amplitudes.jl")  # submodule Amplitudes
+
 include("./generators.jl")  # submodule Generators
+
 
 using .Generators
 export liouvillian, hamiltonian

--- a/src/amplitudes.jl
+++ b/src/amplitudes.jl
@@ -1,0 +1,201 @@
+module Amplitudes
+
+export LockedAmplitude, ShapedAmplitude
+
+import ..Controls: getcontrols, evalcontrols, substitute_controls
+
+
+#### LockedAmplitude ##########################################################
+
+
+"""A time-dependent amplitude that is not a control.
+
+```julia
+ampl = LockedAmplitude(shape)
+```
+
+wraps around `shape`, which must be either a vector of values defined on the
+midpoints of a time grid or a callable `shape(t)`.
+
+```julia
+ampl = LockedAmplitude(shape, tlist)
+```
+
+discretizes `shape` to the midpoints of `tlist`.
+"""
+abstract type LockedAmplitude end
+
+
+function LockedAmplitude(shape)
+    if shape isa Vector{Float64}
+        return LockedPulseAmplitude(shape)
+    else
+        return LockedContinuousAmplitude(shape)
+    end
+end
+
+
+function LockedAmplitude(shape, tlist)
+    return LockedPulseAmplitude(discretize_on_midpoints(shape, tlist))
+end
+
+
+function Base.show(io::IO, ampl::LockedAmplitude)
+    print(io, "LockedAmplitude(::$(typeof(ampl.shape)))")
+end
+
+
+struct LockedPulseAmplitude <: LockedAmplitude
+    shape::Vector{Float64}
+end
+
+
+Base.Array(ampl::LockedPulseAmplitude) = ampl.shape
+
+
+struct LockedContinuousAmplitude <: LockedAmplitude
+
+    shape
+
+    function LockedContinuousAmplitude(shape)
+        try
+            S_t = shape(0.0)
+        catch
+            error("A LockedAmplitude shape must either be a vector of values or a callable")
+        end
+        return new(shape)
+    end
+
+end
+
+(ampl::LockedContinuousAmplitude)(t::Float64) = ampl.shape(t)
+
+getcontrols(ampl::LockedAmplitude) = ()
+
+substitute_controls(ampl::LockedAmplitude, controls_map) = ampl
+
+function evalcontrols(ampl::LockedPulseAmplitude, vals_dict, tlist, n)
+    return ampl.shape[n]
+end
+
+function evalcontrols(ampl::LockedContinuousAmplitude, vals_dict, tlist, n)
+    # It's technically possible to determine t from (tlist, n), but maybe we
+    # shouldn't
+    error("LockedAmplitude must be initialized with tlist")
+end
+
+
+#### ControlAmplitude #########################################################
+
+
+# An amplitude that has `control` as the first field
+abstract type ControlAmplitude end
+
+getcontrols(ampl::ControlAmplitude) = (ampl.control,)
+
+function substitute_controls(ampl::CT, controls_map) where {CT<:ControlAmplitude}
+    control = get(controls_map, ampl.control, ampl.control)
+    CT(control, (getfield(ampl, field) for field in fieldnames(CT)[2:end])...)
+end
+
+
+#### ShapedAmplitude ##########################################################
+
+
+"""Product of a fixed shape and a control.
+
+```julia
+ampl = ShapedAmplitude(control; shape=shape)
+```
+
+produces an amplitude ``a(t) = S(t) ϵ(t)``, where ``S(t)`` corresponds to
+`shape` and ``ϵ(t)`` corresponds to `control`. Both `control` and `shape`
+should be either a vector of values defined on the midpoints of a time grid or
+a callable `control(t)`, respectively `shape(t)`. In the latter case, `ampl`
+will also be callable.
+
+```julia
+ampl = ShapedAmplitude(control, tlist; shape=shape)
+```
+
+discretizes `control` and `shape` to the midpoints of `tlist`.
+"""
+abstract type ShapedAmplitude <: ControlAmplitude end
+
+function ShapedAmplitude(control; shape)
+    if (control isa Vector{Float64}) && (shape isa Vector{Float64})
+        return ShapedPulseAmplitude(control, shape)
+    else
+        try
+            ϵ_t = control(0.0)
+        catch
+            error(
+                "A ShapedAmplitude control must either be a vector of values or a callable"
+            )
+        end
+        try
+            S_t = shape(0.0)
+        catch
+            error("A ShapedAmplitude shape must either be a vector of values or a callable")
+        end
+        return ShapedContinuousAmplitude(control, shape)
+    end
+end
+
+function Base.show(io::IO, ampl::ShapedAmplitude)
+    print(io, "ShapedAmplitude(::$(typeof(ampl.control)); shape::$(typeof(ampl.shape)))")
+end
+
+function ShapedAmplitude(control, tlist; shape)
+    control = discretize_on_midpoints(control, tlist)
+    shape = discretize_on_midpoints(shape, tlist)
+    return ShapedPulseAmplitude(control, shape)
+end
+
+struct ShapedPulseAmplitude <: ShapedAmplitude
+    control::Vector{Float64}
+    shape::Vector{Float64}
+end
+
+Base.Array(ampl::ShapedPulseAmplitude) = ampl.control .* ampl.shape
+
+
+struct ShapedContinuousAmplitude <: ShapedAmplitude
+    control
+    shape
+end
+
+(ampl::ShapedContinuousAmplitude)(t::Float64) = ampl.shape(t) * ampl.control(t)
+
+
+"""
+```julia
+aₙ = evalcontrols(ampl, vals_dict)
+```
+
+evaluates a general control amplitude by replacing each control with the
+values in `vals_dict`. Returns a number.
+
+Note that for "trivial" amplitudes (where the amplitude is identical to the
+control), this simply looks up the control in `vals_dict`.
+
+For amplitudes with explicit time dependencies (outside of the controls),
+additional parameters `tlist, n` or `t` should be given to indicate the time at
+which the amplitude is to be evaluated.
+"""
+evalcontrols(ampl::Function, vals_dict, _...) = vals_dict[ampl]
+evalcontrols(ampl::Vector, vals_dict, _...) = vals_dict[ampl]
+
+
+function evalcontrols(ampl::ShapedPulseAmplitude, vals_dict, tlist, n)
+    return ampl.shape[n] * vals_dict[ampl.control]
+end
+
+function evalcontrols(ampl::ShapedContinuousAmplitude, vals_dict, tlist, n)
+    # It's technically possible to determind t from (tlist, n), but maybe we
+    # shouldn't
+    error("ShapedAmplitude must be initialized with tlist")
+end
+
+
+end

--- a/src/cheby_propagator.jl
+++ b/src/cheby_propagator.jl
@@ -1,3 +1,5 @@
+using .Controls: getcontrols, evalcontrols, discretize
+
 """Propagator for Chebychev propagation (`method=:cheby`).
 
 This is a [`PWCPropagator`](@ref).
@@ -50,12 +52,13 @@ initializes a [`ChebyPropagator`](@ref).
 # Method-specific keyword arguments
 
 * `control_ranges`: a dict the maps the controls in `generator` (see
-  [`getcontrols`](@ref)) to a tuple of min/max values. The Chebychev
-  coefficients will be calculated based on a spectral envelope that assumes
-  that each control can take arbitrary values within the min/max range. If not
-  given, the ranges are determined automatically. Specifying manual control
-  ranges can be useful when the the control amplitudes (`parameters`) may
-  change during the propagation, e.g. in a sequential-update control scheme.
+  [`getcontrols`](@ref QuantumPropagators.Controls.getcontrols)) to a tuple of
+  min/max values. The Chebychev coefficients will be calculated based on a
+  spectral envelope that assumes that each control can take arbitrary values
+  within the min/max range. If not given, the ranges are determined
+  automatically. Specifying manual control ranges can be useful when the the
+  control amplitudes (`parameters`) may change during the propagation, e.g. in
+  a sequential-update control scheme.
 * `specrange_method`: Method to pass to the [`specrange`](@ref
   QuantumPropagators.SpectralRange.specrange) function
 * `specrange_buffer`: An additional factor by which to enlarge the estimated

--- a/src/controls.jl
+++ b/src/controls.jl
@@ -1,0 +1,308 @@
+module Controls
+
+export discretize, discretize_on_midpoints
+export getcontrols
+export get_tlist_midpoints
+export evalcontrols, evalcontrols!, substitute_controls
+
+using LinearAlgebra
+
+
+"""Evaluate `control` at every point of `tlist`.
+
+```julia
+values = discretize(control, tlist; via_midpoints=true)
+```
+
+discretizes the given `control` to a Vector of values defined on the points of
+`tlist`.
+
+If `control` is a function, it will will first be evaluated at the midpoint of
+`tlist`, see [`discretize_on_midpoints`](@ref), and then the values on the
+midpoints are converted to values on `tlist`. This discretization is more
+stable than directly evaluationg the control function at the values of `tlist`,
+and ensures that repeated round-trips between [`discretize`](@ref) and
+[`discretize_on_midpoints`](@ref) can be done safely, see the note in the
+documentation of [`discretize_on_midpoints`](@ref).
+
+The latter can still be achieved by passing `via_midpoints=false`. While such a
+direct discretization is suitable e.g. for plotting, but it is unsuitable
+for round-trips between [`discretize`](@ref) and
+[`discretize_on_midpoints`](@ref)  (constant controls on `tlist` may result in
+a zig-zag on the intervals of `tlist`).
+
+If `control` is a vector, it will be returned un-modified if it is of the same
+length as `tlist`. Otherwise, `control` must have one less value than `tlist`,
+and is assumed to be defined on the midpoins of `tlist`. In that case,
+[`discretize`](@ref) acts as the inverse of [`discretize_on_midpoints`](@ref).
+See [`discretize_on_midpoints`](@ref) for how control values on `tlist` and
+control values on the intervals of `tlist` are related.
+"""
+function discretize(control::Function, tlist; via_midpoints=true)
+    if via_midpoints
+        vals_on_midpoints = discretize_on_midpoints(control, tlist)
+        return discretize(vals_on_midpoints, tlist)
+    else
+        return [control(t) for t in tlist]
+    end
+end
+
+function discretize(control::Vector, tlist)
+    if length(control) == length(tlist)
+        return control
+    elseif length(control) == length(tlist) - 1
+        # convert `control` on intervals to values on `tlist`
+        # cf. pulse_onto_tlist in Python krotov package
+        vals = zeros(eltype(control), length(control) + 1)
+        vals[1] = control[1]
+        vals[end] = control[end]
+        for i = 2:length(vals)-1
+            vals[i] = 0.5 * (control[i-1] + control[i])
+        end
+        return vals
+    else
+        throw(ArgumentError("control array must be defined on intervals of tlist"))
+    end
+end
+
+
+"""Shift time grid values the interval midpoints
+
+```julia
+tlist_midpoints = get_tlist_midpoints(tlist)
+```
+
+takes a vector `tlist` of length ``n`` and returns a vector of length ``n-1``
+containing the midpoint values of each interval. The intervals in `tlist` are
+not required to be uniform.
+"""
+function get_tlist_midpoints(tlist)
+    tlist_midpoints = zeros(eltype(tlist), length(tlist) - 1)
+    tlist_midpoints[1] = tlist[1]
+    tlist_midpoints[end] = tlist[end]
+    for i = 2:length(tlist_midpoints)-1
+        dt = tlist[i+1] - tlist[i]
+        tlist_midpoints[i] = tlist[i] + 0.5 * dt
+    end
+    return tlist_midpoints
+end
+
+
+@doc raw"""
+Evaluate `control` at the midpoints of `tlist`.
+
+```julia
+values = discretize_on_midpoints(control, tlist)
+```
+
+discretizes the given `control` to a Vector of values on the midpoints of
+`tlist`. Hence, the resulting `values` will contain one less value than
+`tlist`.
+
+If `control` is a vector of values defined on `tlist` (i.e., of the same length
+as `tlist`), it will be converted to a vector of values on the intervals of
+`tlist`. The value for the first and last "midpoint" will remain the original
+values at the beginning and end of `tlist`, in order to ensure exact bounary
+conditions. For all other midpoints, the value for that midpoint will be
+calculated by "un-averaging".
+
+For example, for a `control` and `tlist` of length 5, consider the following
+diagram:
+
+~~~
+tlist index:       1   2   3   4   5
+tlist:             ⋅   ⋅   ⋅   ⋅   ⋅   input values cᵢ (i ∈ 1..5)
+                   |̂/ ̄ ̄ ̂\ / ̂\ / ̂ ̄ ̄\|̂
+midpoints:         x     x   x     x   output values pᵢ (i ∈ 1..4)
+midpoints index:   1     2   3     4
+~~~
+
+We will have ``p₁=c₁`` for the first value, ``p₄=c₅`` for the last value. For
+all other points, the control values ``cᵢ = \frac{p_{i-1} + p_{i}}{2}`` are the
+average of the values on the midpoints. This implies the "un-averaging" for the
+midpoint values ``pᵢ = 2 c_{i} - p_{i-1}``.
+
+!!! note
+
+    An arbitrary input `control` array may not be compatible with the above
+    averaging formula. In this case, the conversion will be "lossy"
+    ([`discretize`](@ref) will not recover the original `control` array; the
+    difference should be considered a "discretization error"). However, any
+    *further* round-trip conversions between points and intervals are bijective
+    and preserve the boundary conditions. In this case, the
+    [`discretize_on_midpoints`](@ref) and [`discretize`](@ref) methods are each
+    other's inverse. This also implies that for an optimal control procedure,
+    it is safe to modify *midpoint* values. Modifying the the values on the
+    time grid directly on the other hand may accumulate discretization errors.
+
+If `control` is a vector of one less length than `tlist`, it will be returned
+unchanged, under the assumption that the input is already properly discretized.
+
+If `control` is a function, the function will be directly evaluated at the
+midpoints marked as `x` in the above diagram..
+"""
+function discretize_on_midpoints(control::T, tlist) where {T<:Function}
+    return discretize(control, get_tlist_midpoints(tlist); via_midpoints=false)
+end
+
+function discretize_on_midpoints(control::Vector, tlist)
+    if length(control) == length(tlist) - 1
+        return control
+    elseif length(control) == length(tlist)
+        vals = zeros(eltype(control), length(control) - 1)
+        vals[1] = control[1]
+        vals[end] = control[end]
+        for i = 2:length(vals)-1
+            vals[i] = 2 * control[i] - vals[i-1]
+        end
+        return vals
+    else
+        throw(ArgumentError("control array must be defined on the points of tlist"))
+    end
+end
+
+
+"""Extract a Tuple of controls.
+
+```julia
+controls = getcontrols(generator)
+```
+
+extracts the controls from a single dynamical generator.
+
+For example, if `generator = hamiltonian(H0, (H1, ϵ1), (H2, ϵ2))`, extracts
+`(ϵ1, ϵ2)`.
+"""
+getcontrols(ampl::Function) = (ampl,)
+getcontrols(ampl::Vector) = (ampl,)
+getcontrols(ampl::Number) = Tuple([])
+
+
+"""
+```julia
+getcontrols(operator)
+```
+
+for a static operator (matrix) returns an empty tuple.
+"""
+getcontrols(operator::AbstractMatrix) = Tuple([])
+
+
+
+"""Replace the controls in `generator` with static values.
+
+```julia
+op = evalcontrols(generator, vals_dict)
+```
+
+replaces the time-dependent controls in `generator` with the values in
+`vals_dict` and returns the static operator `op`.
+
+The `vals_dict` is a dictionary (`IdDict`) mapping controls as returned by
+`getcontrols(generator)` to values.
+
+```julia
+op = evalcontrols(generator, vals_dict, tlist, n)
+op = evalcontrols(generator, vals_dict, t)
+```
+
+acts similarly for generators that have explicit time dependencies (apart for
+the controls). The additional parameters indicate that `generator` has explicit
+time dependencies that are well-defined on the intervals of a time grid
+`tlist`, and that `vals_dict` should be assumed to relate to the n'th interval
+of that time grid. Respectively, an additional parameter `t` indicates the
+`generator` is a time-continuous explicit dependency and that `vals_dict`
+contains values defined at time `t`.
+
+# See also:
+
+* [`evalcontrols!`](@ref) to update `op` with new `vals_dict`.
+"""
+function evalcontrols(generator::Tuple, vals_dict::AbstractDict, _...)
+    if isa(generator[1], Tuple)
+        control = generator[1][2]
+        op = vals_dict[control] * generator[1][1]
+    else
+        op = copy(generator[1])
+    end
+    for part in generator[2:end]
+        if isa(part, Tuple)
+            control = part[2]
+            op += vals_dict[control] * part[1]
+        else
+            op += part
+        end
+    end
+    return op
+end
+
+evalcontrols(num::Number, vals_dict, _...) = num
+
+evalcontrols(operator::AbstractMatrix, _...) = operator
+
+
+"""Update an existing evaluation of a `generator`.
+
+```julia
+evalcontrols!(op, generator, vals_dict, args...)
+```
+
+performs an in-place update on an `op` the was obtained from a previous call to
+[`evalcontrols`](@ref) with the same `generator`, but a different `val_dict`.
+"""
+function evalcontrols!(op, generator::Tuple, vals_dict::AbstractDict, _...)
+    if generator[1] isa Tuple
+        control = generator[1][2]
+        copyto!(op, generator[1][1])
+        lmul!(vals_dict[control], op)
+    else
+        copyto!(op, generator[1])
+    end
+    for part in generator[2:end]
+        if part isa Tuple
+            control = part[2]
+            axpy!(vals_dict[control], part[1], op)
+        else
+            axpy!(true, part, op)
+        end
+    end
+    return op
+end
+
+
+"""Substitute the controls inside a `generator` with different `controls`.
+
+```julia
+new_generator = substitute_controls(generator, controls_map)
+```
+
+Creates a new generator from `generator` by replacing any control that is in
+the dict `controls_map` with `controls_map[control]`. Controls that are not in
+`controls_map` are kept unchanged.
+
+The substituted controls must be time-dependent; to substitute static values
+for the controls, converting the time-dependent `generator` into a static
+operator, use [`evalcontrols`](@ref).
+
+Calling `substitute_controls` on a static operator will return it unchanged.
+"""
+function substitute_controls(generator::Tuple, controls_map)
+    new_generator = Any[]
+    for part in generator
+        if part isa Tuple
+            operator, control = part
+            new_part = (operator, get(controls_map, control, control))
+            push!(new_generator, new_part)
+        else
+            push!(new_generator, part)
+        end
+    end
+    return Tuple(new_generator)
+end
+
+
+# A static operator has no controls and remains unchanged
+substitute_controls(operator::AbstractMatrix, controls_map) = operator
+
+
+end

--- a/src/exp_propagator.jl
+++ b/src/exp_propagator.jl
@@ -1,3 +1,5 @@
+using .Controls: getcontrols
+
 """Propagator for propagation via direct exponentiation (`method=:expprop`)
 
 This is a [`PWCPropagator`](@ref).

--- a/src/newton_propagator.jl
+++ b/src/newton_propagator.jl
@@ -1,3 +1,5 @@
+using .Controls: getcontrols
+
 """Propagator for Newton propagation (`method=:newton`).
 
 This is a [`PWCPropagator`](@ref).

--- a/src/propagator.jl
+++ b/src/propagator.jl
@@ -49,12 +49,12 @@ abstract type AbstractPropagator end
 
 A piecewise propagator is determined by a single parameter per control and time
 grid interval. Consequently, the `propagator.parameters` are a dictionary
-mapping the controls found in the `generator` via [`getcontrols`](@ref) to a
-vector of values defined on the intervals of the time grid, see
-[`discretize_on_midpoints`](@ref). This does not necessarily imply that these
-values are the piecewise-constant amplitudes for the intervals. A general
-piecwise propagatore might use interpolation to obtain actual amplitudes within
-any given time interval.
+mapping the controls found in the `generator` via [`getcontrols`](@ref
+QuantumPropagators.Controls.getcontrols) to a vector of values defined on the
+intervals of the time grid, see [`discretize_on_midpoints`](@ref). This does
+not necessarily imply that these values are the piecewise-constant amplitudes
+for the intervals. A general piecwise propagatore might use interpolation to
+obtain actual amplitudes within any given time interval.
 
 When the amplitudes *are* piecewise-constant, the propagator should be a
 concrete intantiation of a [`PWCPropagator`](@ref).

--- a/src/pwc_utils.jl
+++ b/src/pwc_utils.jl
@@ -23,6 +23,8 @@
 # functions defined in this file are always called explicitly, not implicitly
 # via dispatch on PiecewisePropagator.
 
+using .Controls: discretize, discretize_on_midpoints, evalcontrols, evalcontrols!
+
 
 function _pwc_process_parameters(parameters, controls, tlist)
     if isnothing(parameters)

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -1,0 +1,110 @@
+module Shapes
+
+export flattop, box, blackman
+
+
+@doc raw"""Flat shape (amplitude 1.0) with a switch-on/switch-off from zero.
+
+```julia
+flattop(t; T, t_rise, t₀=0.0, t_fall=t_rise, func=:blackman)
+```
+
+evaluates a shape function that starts at 0 at ``t=t₀``, and ramps to to 1
+during the `t_rise` interval. The function then remains at value 1, before
+ramping down to 0 again during the interval `t_fall` before `T`. For ``t < t₀``
+and ``t > T``, the shape is zero.
+
+The default switch-on/-off shape is half of a Blackman window (see
+[`blackman`](@ref)).
+
+For `func=:sinsq`, the switch-on/-off shape is a sine-squared curve.
+"""
+function flattop(t; T, t_rise, t₀=0.0, t_fall=t_rise, func=:blackman)
+    if func == :blackman
+        return flattop_blackman(t, t₀, T, t_rise, t_fall)
+    elseif func == :sinsq
+        return flattop_sinsq(t, t₀, T, t_rise, t_fall)
+    else
+        throw(
+            ArgumentError("Unknown func=$func. Accepted values are :blackman and :sinsq.")
+        )
+    end
+end
+
+
+function flattop_sinsq(t, t₀, T, t_rise, t_fall=t_rise)
+    f::Float64 = 0.0
+    if t₀ ≤ t ≤ T
+        f = 1.0
+        if t ≤ t₀ + t_rise
+            f = sin(π * (t - t₀) / (2.0 * t_rise))^2
+        elseif t ≥ T - t_fall
+            f = sin(π * (t - T) / (2.0 * t_fall))^2
+        end
+    end
+    return f
+end
+
+
+function flattop_blackman(t, t₀, T, t_rise, t_fall=t_rise)
+    f::Float64 = 0.0
+    if t₀ ≤ t ≤ T
+        f = 1.0
+        if t ≤ t₀ + t_rise
+            f = blackman(t, t₀, t₀ + 2 * t_rise)
+        elseif t ≥ T - t_fall
+            f = blackman(t, T - 2 * t_fall, T)
+        end
+    end
+    return f
+end
+
+
+@doc raw"""Box shape (Theta-function).
+
+```julia
+box(t, t₀, T)
+```
+
+evaluates the Heaviside (Theta-) function $\Theta(t) = 1$ for $t_0 \le t \le
+T$; and $\Theta(t) = 0$ otherwise.
+"""
+box(t, t₀, T) = (t₀ ≤ t ≤ T) ? 1.0 : 0.0
+
+
+@doc raw"""Blackman window shape.
+
+```julia
+blackman(t, t₀, T; a=0.16)
+```
+
+calculates
+
+```math
+B(t; t_0, T) =
+    \frac{1}{2}\left(
+        1 - a - \cos\left(2π \frac{t - t_0}{T - t_0}\right)
+        + a \cos\left(4π \frac{t - t_0}{T - t_0}\right)
+    \right)\,,
+```
+
+for a scalar `t`, with $a$ = 0.16.
+
+See <http://en.wikipedia.org/wiki/Window_function#Blackman_windows>
+
+A Blackman shape looks nearly identical to a Gaussian with a 6-sigma
+interval between `t₀` and `T`.  Unlike the Gaussian, however, it will go
+exactly to zero at the edges. Thus, Blackman pulses are often preferable to
+Gaussians.
+"""
+function blackman(t, t₀, T; a=0.16)
+    ΔT = T - t₀
+    return (
+        0.5 *
+        box(t, t₀, T) *
+        (1.0 - a - cos(2π * (t - t₀) / ΔT) + a * cos(4π * (t - t₀) / ΔT))
+    )
+end
+
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,11 @@ using SafeTestsets
         include("test_operator_linalg.jl")
     end
 
+    print("\n* Shapes (test_shapes.jl):")
+    @time @safetestset "Shapes" begin
+        include("test_shapes.jl")
+    end
+
     print("\n* Controls (test_controls.jl):")
     @time @safetestset "Controls" begin
         include("test_controls.jl")

--- a/test/test_controls.jl
+++ b/test/test_controls.jl
@@ -1,9 +1,12 @@
 using Test
 using LinearAlgebra
+using Logging
 using QuantumPropagators
 using QuantumPropagators.Generators
+using QuantumPropagators.Controls
 using QuantumPropagators: Generator, Operator
 using QuantumControlBase.TestUtils: random_hermitian_matrix
+
 
 @testset "Simple getcontrols" begin
 
@@ -144,38 +147,6 @@ end
 
 end
 
-
-@testset "Standard getcontrolderivs" begin
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
-    H₂ = random_hermitian_matrix(5, 1.0)
-    ϵ₁ = t -> 1.0
-    ϵ₂ = t -> 1.0
-    H = (H₀, (H₁, ϵ₁), (H₂, ϵ₂))
-
-    @test getcontrolderiv(ϵ₁, ϵ₁) == 1.0
-    @test getcontrolderiv(ϵ₁, ϵ₂) == 0.0
-
-    derivs = getcontrolderivs(H₀, (ϵ₁, ϵ₂))
-    @test all(isnothing.(derivs))
-
-    derivs = getcontrolderivs(H, (ϵ₁, ϵ₂))
-    @test derivs[1] isa Matrix{ComplexF64}
-    @test derivs[2] isa Matrix{ComplexF64}
-    @test norm(derivs[1] - H₁) < 1e-14
-    @test norm(derivs[2] - H₂) < 1e-14
-
-    for deriv in derivs
-        O = evalcontrols(deriv, IdDict(ϵ₁ => 1.1, ϵ₂ => 2.0))
-        @test O ≡ deriv
-    end
-
-    @test isnothing(getcontrolderiv(H, t -> 3.0))
-
-end
-
-_AT(::Generator{OT,AT}) where {OT,AT} = AT
-
 struct MySquareAmpl
     control::Function
 end
@@ -185,13 +156,6 @@ struct MyScaledAmpl
     control::Function
 end
 
-function QuantumPropagators.Generators.getcontrolderiv(a::MySquareAmpl, control)
-    if control ≡ a.control
-        return MyScaledAmpl(2.0, control)
-    else
-        return 0.0
-    end
-end
 
 function QuantumPropagators.Generators.substitute_controls(a::MySquareAmpl, controls_map)
     return MySquareAmpl(get(controls_map, a.control, a.control))
@@ -209,54 +173,27 @@ end
     H₂ = random_hermitian_matrix(5, 1.0)
     ϵ₁ = t -> 1.0
     ϵ₂ = t -> 1.0
-    H = hamiltonian(H₀, (H₁, MySquareAmpl(ϵ₁)), (H₂, MySquareAmpl(ϵ₂)))
 
-    ϵ₁_new = t -> 2.0
-    ϵ₂_new = t -> 2.0
+    with_logger(NullLogger()) do
 
-    @test H isa Generator
-    H_new = substitute_controls(H, IdDict(ϵ₁ => ϵ₁_new, ϵ₂ => ϵ₂_new))
+        H = hamiltonian(H₀, (H₁, MySquareAmpl(ϵ₁)), (H₂, MySquareAmpl(ϵ₂)))
 
-    @test H_new isa Generator
-    @test H_new.ops[1] ≡ H₀
-    @test H_new.ops[2] ≡ H₁
-    @test H_new.ops[3] ≡ H₂
+        ϵ₁_new = t -> 2.0
+        ϵ₂_new = t -> 2.0
 
-    @test H_new.amplitudes[1] isa MySquareAmpl
-    @test H_new.amplitudes[2] isa MySquareAmpl
-    @test H_new.amplitudes[1].control ≡ ϵ₁_new
-    @test H_new.amplitudes[2].control ≡ ϵ₂_new
+        @test H isa Generator
+        H_new = substitute_controls(H, IdDict(ϵ₁ => ϵ₁_new, ϵ₂ => ϵ₂_new))
 
-end
+        @test H_new isa Generator
+        @test H_new.ops[1] ≡ H₀
+        @test H_new.ops[2] ≡ H₁
+        @test H_new.ops[3] ≡ H₂
 
+        @test H_new.amplitudes[1] isa MySquareAmpl
+        @test H_new.amplitudes[2] isa MySquareAmpl
+        @test H_new.amplitudes[1].control ≡ ϵ₁_new
+        @test H_new.amplitudes[2].control ≡ ϵ₂_new
 
-@testset "Nonlinear getcontrolderivs" begin
-
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
-    H₂ = random_hermitian_matrix(5, 1.0)
-    ϵ₁ = t -> 1.0
-    ϵ₂ = t -> 1.0
-    H = (H₀, (H₁, MySquareAmpl(ϵ₁)), (H₂, MySquareAmpl(ϵ₂)))
-
-    derivs = getcontrolderivs(H, (ϵ₁, ϵ₂))
-    @test derivs[1] isa Generator
-    @test derivs[2] isa Generator
-    @test derivs[1].ops[1] ≡ H₁
-    @test _AT(derivs[1]) ≡ MyScaledAmpl
-
-    O₁ = evalcontrols(derivs[1], IdDict(ϵ₁ => 1.1, ϵ₂ => 2.0))
-    @test O₁ isa Operator
-    @test length(O₁.ops) == length(O₁.coeffs) == 1
-    @test O₁.ops[1] ≡ H₁
-    @test O₁.coeffs[1] ≈ (2 * 1.1)
-
-    O₂ = evalcontrols(derivs[2], IdDict(ϵ₁ => 1.1, ϵ₂ => 2.0))
-    @test O₂ isa Operator
-    @test length(O₂.ops) == length(O₂.coeffs) == 1
-    @test O₂.ops[1] ≡ H₂
-    @test O₂.coeffs[1] ≈ (2 * 2.0)
-
-    @test isnothing(getcontrolderiv(H, t -> 3.0))
+    end
 
 end

--- a/test/test_discretization.jl
+++ b/test/test_discretization.jl
@@ -1,6 +1,6 @@
 using Test
-using QuantumPropagators.Generators
-using QuantumControlBase.Shapes: blackman
+using QuantumPropagators.Controls
+using QuantumPropagators.Shapes: blackman
 
 @testset "discretize/discretize_on_midpoints" begin
     tlist = collect(range(0, 10, length=20))

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -5,6 +5,7 @@ using LinearAlgebra
 using QuantumPropagators
 using QuantumPropagators: Generator, Operator
 using QuantumPropagators.Generators: check_generator, check_operator, check_amplitude
+using QuantumControlBase
 using QuantumControlBase.TestUtils:
     random_hermitian_matrix, random_real_matrix, random_state_vector, QuantumTestLogger
 
@@ -50,7 +51,7 @@ end
     end
 
     struct BrokenAmplitude2 end
-    QuantumPropagators.Generators.getcontrols(::BrokenAmplitude2) = (ϵ,)
+    QuantumPropagators.Controls.getcontrols(::BrokenAmplitude2) = (ϵ,)
     @test_throws ErrorException("Invalid control amplitude") begin
         with_logger(test_logger) do
             @info "BrokenAmplitude2"
@@ -59,9 +60,9 @@ end
     end
 
     struct BrokenAmplitude3 end
-    QuantumPropagators.Generators.getcontrols(::BrokenAmplitude3) = (ϵ,)
-    QuantumPropagators.Generators.evalcontrols(::BrokenAmplitude3, _...) = nothing
-    QuantumPropagators.Generators.getcontrolderiv(::BrokenAmplitude3, _) = nothing
+    QuantumPropagators.Controls.getcontrols(::BrokenAmplitude3) = (ϵ,)
+    QuantumPropagators.Controls.evalcontrols(::BrokenAmplitude3, _...) = nothing
+    QuantumControlBase.getcontrolderiv(::BrokenAmplitude3, _) = nothing
     @test_throws ErrorException("Invalid control amplitude") begin
         with_logger(test_logger) do
             @info "BrokenAmplitude3"
@@ -70,7 +71,7 @@ end
     end
 
     struct BrokenAmplitude4 end
-    QuantumPropagators.Generators.getcontrols(::BrokenAmplitude4) = error("Not implemented")
+    QuantumPropagators.Controls.getcontrols(::BrokenAmplitude4) = error("Not implemented")
     @test_throws ErrorException("Not implemented") begin
         with_logger(test_logger) do
             @info "BrokenAmplitude4"
@@ -79,8 +80,8 @@ end
     end
 
     struct BrokenAmplitude5 end
-    QuantumPropagators.Generators.getcontrols(::BrokenAmplitude5) = (ϵ,)
-    QuantumPropagators.Generators.evalcontrols(::BrokenAmplitude5, _...) =
+    QuantumPropagators.Controls.getcontrols(::BrokenAmplitude5) = (ϵ,)
+    QuantumPropagators.Controls.evalcontrols(::BrokenAmplitude5, _...) =
         error("Not implemented")
     @test_throws ErrorException("Not implemented") begin
         with_logger(test_logger) do
@@ -90,10 +91,9 @@ end
     end
 
     struct BrokenAmplitude6 end
-    QuantumPropagators.Generators.getcontrols(::BrokenAmplitude6) = (ϵ,)
-    QuantumPropagators.Generators.evalcontrols(::BrokenAmplitude6, _...) = 1.0
-    QuantumPropagators.Generators.getcontrolderiv(::BrokenAmplitude6, _) =
-        error("Not implemented")
+    QuantumPropagators.Controls.getcontrols(::BrokenAmplitude6) = (ϵ,)
+    QuantumPropagators.Controls.evalcontrols(::BrokenAmplitude6, _...) = 1.0
+    QuantumControlBase.getcontrolderiv(::BrokenAmplitude6, _) = error("Not implemented")
     @test_throws ErrorException("Invalid control amplitude") begin
         with_logger(test_logger) do
             @info "BrokenAmplitude6"
@@ -102,8 +102,8 @@ end
     end
 
     struct BrokenAmplitude7 end
-    QuantumPropagators.Generators.getcontrols(::BrokenAmplitude7) = (ϵ,)
-    QuantumPropagators.Generators.evalcontrols(::BrokenAmplitude7, _...) = 1.0
+    QuantumPropagators.Controls.getcontrols(::BrokenAmplitude7) = (ϵ,)
+    QuantumPropagators.Controls.evalcontrols(::BrokenAmplitude7, _...) = 1.0
     @test_throws ErrorException("Invalid control amplitude") begin
         with_logger(test_logger) do
             @info "BrokenAmplitude7"
@@ -140,7 +140,7 @@ end
     end
 
     struct BrokenGenerator end
-    QuantumPropagators.Generators.getcontrols(::BrokenGenerator) = (ϵ₁, ϵ₂)
+    QuantumPropagators.Controls.getcontrols(::BrokenGenerator) = (ϵ₁, ϵ₂)
     @test_throws ErrorException("Invalid generator") begin
         with_logger(test_logger) do
             @info "BrokenGenerator"
@@ -149,8 +149,8 @@ end
     end
 
     struct BrokenGenerator2 end
-    QuantumPropagators.Generators.getcontrols(::BrokenGenerator2) = (ϵ₁, ϵ₂)
-    QuantumPropagators.Generators.evalcontrols(::BrokenGenerator2, _...) = nothing
+    QuantumPropagators.Controls.getcontrols(::BrokenGenerator2) = (ϵ₁, ϵ₂)
+    QuantumPropagators.Controls.evalcontrols(::BrokenGenerator2, _...) = nothing
     @test_throws ErrorException("Invalid generator") begin
         with_logger(test_logger) do
             @info "BrokenGenerator2"
@@ -159,9 +159,9 @@ end
     end
 
     struct BrokenGenerator3 end
-    QuantumPropagators.Generators.getcontrols(::BrokenGenerator3) = (ϵ₁, ϵ₂)
-    QuantumPropagators.Generators.evalcontrols(::BrokenGenerator3, _...) = H₀
-    QuantumPropagators.Generators.getcontrolderiv(::BrokenGenerator3, _) =
+    QuantumPropagators.Controls.getcontrols(::BrokenGenerator3) = (ϵ₁, ϵ₂)
+    QuantumPropagators.Controls.evalcontrols(::BrokenGenerator3, _...) = H₀
+    QuantumControlBase.getcontrolderiv(::BrokenGenerator3, _) =
         random_hermitian_matrix(5, 1.0)
     @test_throws ErrorException("Invalid generator") begin
         with_logger(test_logger) do
@@ -171,9 +171,9 @@ end
     end
 
     struct BrokenGenerator4 end
-    QuantumPropagators.Generators.getcontrols(::BrokenGenerator4) = (ϵ₁, ϵ₂)
-    QuantumPropagators.Generators.evalcontrols(::BrokenGenerator4, _...) = H₀
-    QuantumPropagators.Generators.getcontrolderiv(::BrokenGenerator4, _) = nothing
+    QuantumPropagators.Controls.getcontrols(::BrokenGenerator4) = (ϵ₁, ϵ₂)
+    QuantumPropagators.Controls.evalcontrols(::BrokenGenerator4, _...) = H₀
+    QuantumControlBase.getcontrolderiv(::BrokenGenerator4, _) = nothing
     @test_throws ErrorException("Invalid generator") begin
         with_logger(test_logger) do
             @info "BrokenGenerator4"
@@ -182,8 +182,8 @@ end
     end
 
     struct BrokenGenerator5 end
-    QuantumPropagators.Generators.getcontrols(::BrokenGenerator5) = (ϵ₁, ϵ₂)
-    QuantumPropagators.Generators.evalcontrols(::BrokenGenerator5, _...) =
+    QuantumPropagators.Controls.getcontrols(::BrokenGenerator5) = (ϵ₁, ϵ₂)
+    QuantumPropagators.Controls.evalcontrols(::BrokenGenerator5, _...) =
         error("Not Implemented")
     @test_throws ErrorException("Not Implemented") begin
         with_logger(test_logger) do
@@ -193,7 +193,7 @@ end
     end
 
     struct BrokenGenerator6 end
-    QuantumPropagators.Generators.getcontrols(::BrokenGenerator6) = error("Not Implemented")
+    QuantumPropagators.Controls.getcontrols(::BrokenGenerator6) = error("Not Implemented")
     @test_throws ErrorException("Not Implemented") begin
         with_logger(test_logger) do
             @info "BrokenGenerator6"
@@ -202,9 +202,9 @@ end
     end
 
     struct BrokenGenerator7 end
-    QuantumPropagators.Generators.getcontrols(::BrokenGenerator7) = (ϵ₁, ϵ₂)
-    QuantumPropagators.Generators.evalcontrols(::BrokenGenerator7, _...) = H₀
-    QuantumPropagators.Generators.getcontrolderiv(::BrokenGenerator7, control) =
+    QuantumPropagators.Controls.getcontrols(::BrokenGenerator7) = (ϵ₁, ϵ₂)
+    QuantumPropagators.Controls.evalcontrols(::BrokenGenerator7, _...) = H₀
+    QuantumControlBase.getcontrolderiv(::BrokenGenerator7, control) =
         error("Not Implemented")
     @test_throws ErrorException("Invalid generator") begin
         with_logger(test_logger) do

--- a/test/test_liouvillian.jl
+++ b/test/test_liouvillian.jl
@@ -1,6 +1,7 @@
 using Test
 using QuantumPropagators
 using QuantumPropagators.Generators
+using QuantumPropagators.Controls
 using LinearAlgebra
 using Distributions
 using QuantumControlBase.TestUtils

--- a/test/test_shapes.jl
+++ b/test/test_shapes.jl
@@ -1,0 +1,30 @@
+using Test
+using QuantumPropagators.Shapes
+
+
+@testset "flattop-blackman" begin
+    shape(v) = flattop(v, t₀=10, T=20, t_rise=2, func=:blackman)
+    @test shape(9.9) == 0
+    @test shape(10) < 1e-14
+    @test shape(20) < 1e-14
+    @test shape(20.1) == 0
+    @test shape(15) == 1
+
+    tlist = collect(range(0, 30, step=1.0))
+    shape_vec = flattop.(tlist, t₀=10, T=20, t_rise=2, func=:blackman)
+    @test shape_vec[11] == shape(10)
+end
+
+
+@testset "flattop-sinsq" begin
+    shape(v) = flattop(v, t₀=10, T=20, t_rise=2, func=:sinsq)
+    @test shape(9.9) == 0
+    @test shape(10) < 1e-14
+    @test shape(20) < 1e-14
+    @test shape(20.1) == 0
+    @test shape(15) == 1
+
+    tlist = collect(range(0, 30, step=1.0))
+    shape_vec = flattop.(tlist, t₀=10, T=20, t_rise=2, func=:sinsq)
+    @test shape_vec[11] == shape(10)
+end


### PR DESCRIPTION
This is a refactoring. These modules are moved from `QuantumControlBase`. The `Controls` submodule contains methods previously defined in `Generators`.