### PR TITLE
Refactor to add underscores to method names

### DIFF
--- a/docs/generate_api.jl
+++ b/docs/generate_api.jl
@@ -61,9 +61,9 @@ The highest-level API of the `QuantumPropagators.jl` package consists of a singl
 
 At a slightly lower level, propagation of quantum states in encapsulated by [The Propagator interface](@ref):
 
-* [`initprop`](@ref) — Initialize a `propagator` object, which is of some concrete (method-dependent) sub-type of [`AbstractPropagator`](@ref QuantumPropagators.AbstractPropagator)
-* [`reinitprop!`](@ref) — Re-initialize the `propagator`
-* [`propstep!`](@ref) — Advance the `propagator`  by a single time step forward or backward
+* [`init_prop`](@ref) — Initialize a `propagator` object, which is of some concrete (method-dependent) sub-type of [`AbstractPropagator`](@ref QuantumPropagators.AbstractPropagator)
+* [`reinit_prop!`](@ref) — Re-initialize the `propagator`
+* [`prop_step!`](@ref) — Advance the `propagator`  by a single time step forward or backward
 * [`set_state!`](@ref) — Mutate the current quantum `state` of the `propagator`.
 * [`set_t!`](@ref QuantumPropagators.set_t!) — Mutate the current time of the `propagator` (**not exported**)
 

--- a/docs/src/generators.md
+++ b/docs/src/generators.md
@@ -18,12 +18,12 @@ where ``L`` is the Liouvillian up to a factor of ``i``, see [`liouvillian`](@ref
 
 While the generator may have an explicit time dependency, in the context of optimal control the time dependency will usually be implicit in a dependency of the generator on one or more control functions. That is, ``Ĥ(t) = Ĥ(\{ϵ_l(t)\}, t)``. Any object passed to [`propagate`](@ref) as a `generator` must implement the following methods:
 
-* [`QuantumPropagators.Controls.getcontrols`](@ref) — extract the controls ``\{ϵ_l(t)\}`` from ``Ĥ(\{ϵ_l(t)\}, t)``
+* [`QuantumPropagators.Controls.get_controls`](@ref) — extract the controls ``\{ϵ_l(t)\}`` from ``Ĥ(\{ϵ_l(t)\}, t)``
 * [`QuantumPropagators.Controls.evalcontrols`](@ref), [`QuantumPropagators.Controls.evalcontrols!`](@ref) — plug in values for the controls as well as any explicit time dependency to produce a static operator from the time-dependent generator
 * [`QuantumPropagators.Controls.substitute_controls`](@ref)  — replace the controls with different (e.g., optimized) controls, producing a new time-dependent generator
 
 ```raw COMMENT
-* [`QuantumPropagators.Controls.getcontrolderiv`](@ref) — return ``\frac{∂ Ĥ(\{ϵ_{l'}(t)\}, t)}{∂ ϵ_l(t)}``. The result may be `nothing` if ``Ĥ(t)`` does not depend on the particular ``ϵ_l(t)``, a static operator if ``Ĥ(t)`` is linear in the control ``ϵ_l(t)`` and has no explicit time dependency, or a new time-dependent generator to be evaluated via [`evalcontrols`](@ref QuantumPropagators.Generators.evalcontrols) otherwise.
+* [`QuantumPropagators.Controls.get_control_deriv`](@ref) — return ``\frac{∂ Ĥ(\{ϵ_{l'}(t)\}, t)}{∂ ϵ_l(t)}``. The result may be `nothing` if ``Ĥ(t)`` does not depend on the particular ``ϵ_l(t)``, a static operator if ``Ĥ(t)`` is linear in the control ``ϵ_l(t)`` and has no explicit time dependency, or a new time-dependent generator to be evaluated via [`evalcontrols`](@ref QuantumPropagators.Generators.evalcontrols) otherwise.
 ```
 
 When writing a custom generator type, the [`QuantumPropagators.Generators.check_generator`](@ref) routine should be used to check that all of these methods are implemented.
@@ -42,14 +42,14 @@ that is, an (optional) drift term ``Ĥ₀`` and an arbitrary number of control 
 
 In the form represented by a [`Generator`](@ref QuantumPropagators.Generators.Generator), the time-dependence of the control terms is via control amplitudes ``a_l(\{ϵ_{l'}(t)\}, t)``, which may depend on one or more control function ``\{ϵ_{l'}(t)\}``. In most cases, ``a_l(t) ≡ ϵ_l(t)``. Any other dependency of the control amplitudes on the control functions must be implemented via a custom type, for which the following methods must be defined:
 
-* [`QuantumPropagators.Controls.getcontrols`](@ref)
+* [`QuantumPropagators.Controls.get_controls`](@ref)
 * [`QuantumPropagators.Controls.evalcontrols`](@ref)
 * [`QuantumPropagators.Controls.substitute_controls`](@ref)
 
 These are similar to the equivalent methods for a custom generator. However, [`QuantumPropagators.Controls.evalcontrols`](@ref) for an amplitude returns a number, not an operator.
 
 ```raw COMMENT
-Also, [`QuantumPropagators.Controls.getcontrolderiv`](@ref) returns `0.0` if the control amplitude does not depend on a particular control function, instead of `nothing`.
+Also, [`QuantumPropagators.Controls.get_control_deriv`](@ref) returns `0.0` if the control amplitude does not depend on a particular control function, instead of `nothing`.
 ```
 
 Any custom amplitude implementation should be checked with [`QuantumPropagators.Generators.check_amplitude`](@ref)

--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -4,10 +4,10 @@
 
 * Define a new sub-type of [`AbstractPropagator`](@ref QuantumPropagators.AbstractPropagator) type that is unique to the propagation method, e.g. `MyNewMethodPropagator`. If appropriate, sub-type [`PiecewisePropagator`](@ref QuantumPropagators.PiecewisePropagator) or [`PWCPropagator`](@ref QuantumPropagators.PWCPropagator).
 
-* Choose a name for the propagation method, e.g. `mynewmethod` and implement a new [`initprop`](@ref) method with the following signature
+* Choose a name for the propagation method, e.g. `mynewmethod` and implement a new [`init_prop`](@ref) method with the following signature
 
   ```
-  function initprop(
+  function init_prop(
       state,
       generator,
       tlist,
@@ -21,6 +21,6 @@
   )
   ```
 
-  Note the `method::Val{:mynewmethod}` as the fourth positional parameter. While the *public* interface for [`initprop`](@ref) takes `method` as a keyword argument, privately [`initprop`](@ref) dispatches for different methods as above.
+  Note the `method::Val{:mynewmethod}` as the fourth positional parameter. While the *public* interface for [`init_prop`](@ref) takes `method` as a keyword argument, privately [`init_prop`](@ref) dispatches for different methods as above.
 
 * Implement the remaining methods in [The Propagator interface](@ref)

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -98,31 +98,31 @@ Open quantum systems are handled identically to closed quantum system, except th
 
 ## The Propagator interface
 
-As a lower-level interface than [`propagate`](@ref), the `QuantumPropagators` package defines an interface for "propagator" objects. These are initialized via [`initprop`](@ref) as, e.g.,
+As a lower-level interface than [`propagate`](@ref), the `QuantumPropagators` package defines an interface for "propagator" objects. These are initialized via [`init_prop`](@ref) as, e.g.,
 
 ```
-using QuantumPropagators: initprop
+using QuantumPropagators: init_prop
 
-propagator = initprop(Ψ₀, H, tlist)
+propagator = init_prop(Ψ₀, H, tlist)
 ```
 
 The `propagator` is a propagation-method-dependent object with the interface described by [`AbstractPropagator`](@ref).
 
-The  [`propstep!`](@ref) function can then be used to advance the `propagator`:
+The  [`prop_step!`](@ref) function can then be used to advance the `propagator`:
 
 ```@meta
 DocTestSetup = quote
-    using QuantumPropagators: initprop
-    propagator = initprop(Ψ₀, H, tlist)
+    using QuantumPropagators: init_prop
+    propagator = init_prop(Ψ₀, H, tlist)
 end
 ```
 
 ```jldoctest overview
-using QuantumPropagators: propstep!
+using QuantumPropagators: prop_step!
 
-Ψ = propstep!(propagator)  # single step
+Ψ = prop_step!(propagator)  # single step
 
-while !isnothing(propstep!(propagator)); end  # go to end
+while !isnothing(prop_step!(propagator)); end  # go to end
 Ψ = propagator.state
 
 print("Ψ = $(round.(Ψ; digits=3)))\n")
@@ -136,7 +136,7 @@ t = 0.5π
 
 ## Backward propagation
 
-When [`propagate`](@ref) or [`initprop`](@ref) are called with `backward=true`, the propagation is initialized to run backward. The initial state is then defined at `propagator.t == tlist[end]` and each [`propstep!`](@ref) moves to the previous point in `tlist`. The equation of motion is the Schrödinger or Liouville equation with a negative $dt$. Note that the propagation uses the `generator` as it is defined: no automatic adjoint will be taken.
+When [`propagate`](@ref) or [`init_prop`](@ref) are called with `backward=true`, the propagation is initialized to run backward. The initial state is then defined at `propagator.t == tlist[end]` and each [`prop_step!`](@ref) moves to the previous point in `tlist`. The equation of motion is the Schrödinger or Liouville equation with a negative $dt$. Note that the propagation uses the `generator` as it is defined: no automatic adjoint will be taken.
 
 
 ## Connection to DifferentialEquations.jl
@@ -145,13 +145,13 @@ The `QuantumPropagators` API is structured similarly to the [DifferentialEquatio
 
 * The [`propagate`](@ref) function is similar to [`DifferentialEquations.solve`](https://diffeq.sciml.ai/stable/basics/overview/#Solving-the-Problems)
 
-* The [`initprop`](@ref) function is similar to [`DifferentialEquations.init`](https://diffeq.sciml.ai/stable/basics/integrator/#Initialization-and-Stepping)
+* The [`init_prop`](@ref) function is similar to [`DifferentialEquations.init`](https://diffeq.sciml.ai/stable/basics/integrator/#Initialization-and-Stepping)
 
-* The [`reinitprop!`](@ref) function is similar to [`DifferentialEquations.reinit!`](https://diffeq.sciml.ai/stable/basics/integrator/#SciMLBase.reinit!)
+* The [`reinit_prop!`](@ref) function is similar to [`DifferentialEquations.reinit!`](https://diffeq.sciml.ai/stable/basics/integrator/#SciMLBase.reinit!)
 
 * [The Propagator interface](@ref) is similar to DifferentialEquations' [Integrator Interface](https://diffeq.sciml.ai/stable/basics/integrator/)
 
-* [`propstep!`](@ref) corresponds to [`DifferentialEquations.step!`](https://diffeq.sciml.ai/stable/basics/integrator/#SciMLBase.step!)
+* [`prop_step!`](@ref) corresponds to [`DifferentialEquations.step!`](https://diffeq.sciml.ai/stable/basics/integrator/#SciMLBase.step!)
 
 * [`set_state!`](@ref) corresponds to [`DifferentialEquations.set_u!`](https://diffeq.sciml.ai/stable/basics/integrator/#SciMLBase.set_u!)
 

--- a/src/QuantumPropagators.jl
+++ b/src/QuantumPropagators.jl
@@ -24,7 +24,7 @@ using .Generators
 export liouvillian, hamiltonian
 
 include("./propagator.jl")
-export initprop, reinitprop!, propstep!, set_state!
+export init_prop, reinit_prop!, prop_step!, set_state!
 # not exported: set_t!, choose_propmethod
 
 include("./pwc_utils.jl")

--- a/src/amplitudes.jl
+++ b/src/amplitudes.jl
@@ -2,7 +2,7 @@ module Amplitudes
 
 export LockedAmplitude, ShapedAmplitude
 
-import ..Controls: getcontrols, evalcontrols, substitute_controls, discretize_on_midpoints
+import ..Controls: get_controls, evalcontrols, substitute_controls, discretize_on_midpoints
 
 
 #### LockedAmplitude ##########################################################
@@ -70,7 +70,7 @@ end
 
 (ampl::LockedContinuousAmplitude)(t::Float64) = ampl.shape(t)
 
-getcontrols(ampl::LockedAmplitude) = ()
+get_controls(ampl::LockedAmplitude) = ()
 
 substitute_controls(ampl::LockedAmplitude, controls_map) = ampl
 
@@ -91,7 +91,7 @@ end
 # An amplitude that has `control` as the first field
 abstract type ControlAmplitude end
 
-getcontrols(ampl::ControlAmplitude) = (ampl.control,)
+get_controls(ampl::ControlAmplitude) = (ampl.control,)
 
 function substitute_controls(ampl::CT, controls_map) where {CT<:ControlAmplitude}
     control = get(controls_map, ampl.control, ampl.control)

--- a/src/cheby_propagator.jl
+++ b/src/cheby_propagator.jl
@@ -1,4 +1,4 @@
-using .Controls: getcontrols, evalcontrols, discretize
+using .Controls: get_controls, evalcontrols, discretize
 
 """Propagator for Chebychev propagation (`method=:cheby`).
 
@@ -29,7 +29,7 @@ set_t!(propagator::ChebyPropagator, t) = _pwc_set_t!(propagator, t)
 
 """
 ```julia
-cheby_propagator = initprop(
+cheby_propagator = init_prop(
     state,
     generator,
     tlist;
@@ -52,8 +52,8 @@ initializes a [`ChebyPropagator`](@ref).
 # Method-specific keyword arguments
 
 * `control_ranges`: a dict the maps the controls in `generator` (see
-  [`getcontrols`](@ref QuantumPropagators.Controls.getcontrols)) to a tuple of
-  min/max values. The Chebychev coefficients will be calculated based on a
+  [`get_controls`](@ref QuantumPropagators.Controls.get_controls)) to a tuple
+  of min/max values. The Chebychev coefficients will be calculated based on a
   spectral envelope that assumes that each control can take arbitrary values
   within the min/max range. If not given, the ranges are determined
   automatically. Specifying manual control ranges can be useful when the the
@@ -74,7 +74,7 @@ initializes a [`ChebyPropagator`](@ref).
 * `specrange_kwargs`: All further keyword arguments are passed to the
   [`specrange`](@ref QuantumPropagators.SpectralRange.specrange) function
 """
-function initprop(
+function init_prop(
     state,
     generator,
     tlist,
@@ -91,7 +91,7 @@ function initprop(
     specrange_kwargs...
 )
     tlist = convert(Vector{Float64}, tlist)
-    controls = getcontrols(generator)
+    controls = get_controls(generator)
     controlvals = [discretize(control, tlist) for control in controls]
 
     G = _pwc_get_max_genop(generator, controls, tlist)
@@ -163,7 +163,7 @@ _transform_control_ranges(c, ϵ_min, ϵ_max, check) = (ϵ_min, ϵ_max)
 
 """
 ```julia
-reinitprop!(
+reinit_prop!(
     propagator::ChebyPropagator,
     state;
     transform_control_ranges=((c, ϵ_min, ϵ_max, check) => (ϵ_min, ϵ_max)),
@@ -204,7 +204,7 @@ amplitudes in `propagator.parameters`.
   will re-calculate the Chebychev coefficients only if the current amplitudes
   differ by more than a factor of two from the ranges that were used when
   initializing the propagator (`control_ranges` parameter in
-  [`initprop`](@ref), which would have had to overestimate the actual
+  [`init_prop`](@ref), which would have had to overestimate the actual
   amplitudes by at least a factor of two).  When re-calculating, the
   `control_ranges` will overestimate the amplitudes by a factor of five. With
   this `transform_control_ranges`, the propagation will be stable as long as
@@ -219,7 +219,7 @@ amplitudes in `propagator.parameters`.
 
 All other keyword arguments are ignored.
 """
-function reinitprop!(
+function reinit_prop!(
     propagator::ChebyPropagator,
     state;
     transform_control_ranges=_transform_control_ranges,
@@ -298,7 +298,7 @@ QuantumPropagators.SpectralRange.specrange) for those operators.
 * `generator`: dynamical generator, e.g. a time-dependent
 * `tlist`: The time grid for the propagation
 * `control_ranges`: a dict that maps controls that occur in `generator` (cf.
-  [`getcontrols`](@ref) to a tuple of mimimum and maximum amplitude for that
+  [`get_controls`](@ref) to a tuple of mimimum and maximum amplitude for that
   control
 * `method`: method name to pass to  [`specrange`](@ref
   QuantumPropagators.SpectralRange.specrange)
@@ -322,7 +322,7 @@ function cheby_get_spectral_envelope(generator, tlist, control_ranges, method; k
 end
 
 
-function propstep!(propagator::ChebyPropagator)
+function prop_step!(propagator::ChebyPropagator)
     Ψ = propagator.state
     H = propagator.genop
     n = propagator.n

--- a/src/controls.jl
+++ b/src/controls.jl
@@ -1,7 +1,7 @@
 module Controls
 
 export discretize, discretize_on_midpoints
-export getcontrols
+export get_controls
 export get_tlist_midpoints
 export evalcontrols, evalcontrols!, substitute_controls
 
@@ -165,7 +165,7 @@ end
 """Extract a Tuple of controls.
 
 ```julia
-controls = getcontrols(generator)
+controls = get_controls(generator)
 ```
 
 extracts the controls from a single dynamical generator.
@@ -173,19 +173,19 @@ extracts the controls from a single dynamical generator.
 For example, if `generator = hamiltonian(H0, (H1, ϵ1), (H2, ϵ2))`, extracts
 `(ϵ1, ϵ2)`.
 """
-getcontrols(ampl::Function) = (ampl,)
-getcontrols(ampl::Vector) = (ampl,)
-getcontrols(ampl::Number) = Tuple([])
+get_controls(ampl::Function) = (ampl,)
+get_controls(ampl::Vector) = (ampl,)
+get_controls(ampl::Number) = Tuple([])
 
 
 """
 ```julia
-getcontrols(operator)
+get_controls(operator)
 ```
 
 for a static operator (matrix) returns an empty tuple.
 """
-getcontrols(operator::AbstractMatrix) = Tuple([])
+get_controls(operator::AbstractMatrix) = Tuple([])
 
 
 
@@ -199,7 +199,7 @@ replaces the time-dependent controls in `generator` with the values in
 `vals_dict` and returns the static operator `op`.
 
 The `vals_dict` is a dictionary (`IdDict`) mapping controls as returned by
-`getcontrols(generator)` to values.
+`get_controls(generator)` to values.
 
 ```julia
 op = evalcontrols(generator, vals_dict, tlist, n)

--- a/src/exp_propagator.jl
+++ b/src/exp_propagator.jl
@@ -1,4 +1,4 @@
-using .Controls: getcontrols
+using .Controls: get_controls
 
 """Propagator for propagation via direct exponentiation (`method=:expprop`)
 
@@ -26,7 +26,7 @@ set_t!(propagator::ExpPropagator, t) = _pwc_set_t!(propagator, t)
 
 
 # We may want to choose the defaults for convert_state, convert_operator in
-# initprop based on the type of objects we are dealing with. See e.g.
+# init_prop based on the type of objects we are dealing with. See e.g.
 # GradVector/GradgenOperator
 _exp_prop_convert_state(state) = typeof(state)
 _exp_prop_convert_operator(::Any) = Any
@@ -36,7 +36,7 @@ _exp_prop_convert_operator(::ScaledOperator) = Matrix{ComplexF64}
 
 """
 ```julia
-exp_propagator = initprop(
+exp_propagator = init_prop(
     state,
     generator,
     tlist,
@@ -72,7 +72,7 @@ methods to calculate `func` are not defined. Often, it is easier to temporarily
 convert them to standard complex matrices and vectors than to implement the
 missing methods.
 """
-function initprop(
+function init_prop(
     state,
     generator,
     tlist,
@@ -94,7 +94,7 @@ function initprop(
         # so it can be an abstract type.
     end
     tlist = convert(Vector{Float64}, tlist)
-    controls = getcontrols(generator)
+    controls = get_controls(generator)
     G = _pwc_get_max_genop(generator, controls, tlist)
 
     parameters = _pwc_process_parameters(parameters, controls, tlist)
@@ -128,7 +128,7 @@ function initprop(
 end
 
 
-function propstep!(propagator::ExpPropagator)
+function prop_step!(propagator::ExpPropagator)
     n = propagator.n
     tlist = getfield(propagator, :tlist)
     (0 < n < length(tlist)) || return nothing

--- a/src/newton_propagator.jl
+++ b/src/newton_propagator.jl
@@ -1,4 +1,4 @@
-using .Controls: getcontrols
+using .Controls: get_controls
 
 """Propagator for Newton propagation (`method=:newton`).
 
@@ -27,7 +27,7 @@ set_t!(propagator::NewtonPropagator, t) = _pwc_set_t!(propagator, t)
 
 """
 ```julia
-newton_propagator = initprop(
+newton_propagator = init_prop(
     state,
     generator,
     tlist,
@@ -54,7 +54,7 @@ initializes a [`NewtonPropagator`](@ref).
 * `func`, `norm_min`, `relerr`, `max_restarts`: parameter to pass to
   [`newton!`](@ref QuantumPropagators.Newton.newton!)
 """
-function initprop(
+function init_prop(
     state,
     generator,
     tlist,
@@ -71,7 +71,7 @@ function initprop(
     _...
 )
     tlist = convert(Vector{Float64}, tlist)
-    controls = getcontrols(generator)
+    controls = get_controls(generator)
     G = _pwc_get_max_genop(generator, controls, tlist)
 
     parameters = _pwc_process_parameters(parameters, controls, tlist)
@@ -106,7 +106,7 @@ function initprop(
 end
 
 
-function propstep!(propagator::NewtonPropagator)
+function prop_step!(propagator::NewtonPropagator)
     Ψ = propagator.state
     H = propagator.genop
     n = propagator.n

--- a/src/propagate.jl
+++ b/src/propagate.jl
@@ -46,7 +46,7 @@ state = propagate(
     observables=(<store state>, ),
     callback=nothing,
     showprogress=false,
-    initprop_kwargs...)
+    init_prop_kwargs...)
 ```
 
 propagates `state` of the entire time grid and returns the propagates states,
@@ -81,7 +81,7 @@ or a storage array of data collected during the propagation.
 * `callback`: Function to call after each propagation step. See Notes below.
 * `showprogess`: Whether to show a progress bar. See Notes below.
 
-All remaining keyword arguments are passed to [`initprop`](@ref) to initialize
+All remaining keyword arguments are passed to [`init_prop`](@ref) to initialize
 the [`Propagator`](@ref AbstractPropagator) that is used internally to drive
 the optimization. Unknown keyword arguments will be ignored.
 
@@ -140,7 +140,7 @@ stored states / observable data if `storage=true`.
 
 # See also
 
-* [`initprop`](@ref) — Propagate via a [`Propagator`](@ref AbstractPropagator)
+* [`init_prop`](@ref) — Propagate via a [`Propagator`](@ref AbstractPropagator)
   object
 """
 function propagate(state, generator, tlist; method=Val(:auto), kwargs...)
@@ -167,7 +167,7 @@ function propagate(
 )
     backward = get(kwargs, :backward, false)
 
-    propagator = initprop(state, generator, tlist, method; kwargs...)
+    propagator = init_prop(state, generator, tlist, method; kwargs...)
 
     return_storage = false
     if storage === true
@@ -199,7 +199,7 @@ function propagate(
     end
 
     for (i, t_end) in intervals
-        propstep!(propagator)
+        prop_step!(propagator)
         if storage ≠ nothing
             Storage.write_to_storage!(
                 storage,

--- a/test/test_controls.jl
+++ b/test/test_controls.jl
@@ -8,29 +8,29 @@ using QuantumPropagators: Generator, Operator
 using QuantumControlBase.TestUtils: random_hermitian_matrix
 
 
-@testset "Simple getcontrols" begin
+@testset "Simple get_controls" begin
 
     H₀ = random_hermitian_matrix(5, 1.0)
     H₁ = random_hermitian_matrix(5, 1.0)
     H₂ = random_hermitian_matrix(5, 1.0)
 
-    @test length(getcontrols(H₀)) == 0
+    @test length(get_controls(H₀)) == 0
 
     H = (nothing, (nothing, nothing))
-    @test_throws MethodError getcontrols(H)
+    @test_throws MethodError get_controls(H)
 
     ϵ₁ = t -> t
     ϵ₂ = t -> 0.0
     H = (H₀, (H₁, ϵ₁), (H₂, ϵ₂))
-    @test getcontrols(H) == (ϵ₁, ϵ₂)
+    @test get_controls(H) == (ϵ₁, ϵ₂)
 
     H = (H₀, (H₁, ϵ₁), (H₂, ϵ₁))
-    @test getcontrols(H) == (ϵ₁,)
+    @test get_controls(H) == (ϵ₁,)
 
     u₁ = [0.1, 1.0]
     u₂ = [0.1, 2.0]
     H = (H₁, (H₂, u₁), (H₂, u₂))
-    @test getcontrols(H) == (u₁, u₂)
+    @test get_controls(H) == (u₁, u₂)
 
 end
 

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -51,7 +51,7 @@ end
     end
 
     struct BrokenAmplitude2 end
-    QuantumPropagators.Controls.getcontrols(::BrokenAmplitude2) = (ϵ,)
+    QuantumPropagators.Controls.get_controls(::BrokenAmplitude2) = (ϵ,)
     @test_throws ErrorException("Invalid control amplitude") begin
         with_logger(test_logger) do
             @info "BrokenAmplitude2"
@@ -60,9 +60,9 @@ end
     end
 
     struct BrokenAmplitude3 end
-    QuantumPropagators.Controls.getcontrols(::BrokenAmplitude3) = (ϵ,)
+    QuantumPropagators.Controls.get_controls(::BrokenAmplitude3) = (ϵ,)
     QuantumPropagators.Controls.evalcontrols(::BrokenAmplitude3, _...) = nothing
-    QuantumControlBase.getcontrolderiv(::BrokenAmplitude3, _) = nothing
+    QuantumControlBase.get_control_deriv(::BrokenAmplitude3, _) = nothing
     @test_throws ErrorException("Invalid control amplitude") begin
         with_logger(test_logger) do
             @info "BrokenAmplitude3"
@@ -71,7 +71,7 @@ end
     end
 
     struct BrokenAmplitude4 end
-    QuantumPropagators.Controls.getcontrols(::BrokenAmplitude4) = error("Not implemented")
+    QuantumPropagators.Controls.get_controls(::BrokenAmplitude4) = error("Not implemented")
     @test_throws ErrorException("Not implemented") begin
         with_logger(test_logger) do
             @info "BrokenAmplitude4"
@@ -80,7 +80,7 @@ end
     end
 
     struct BrokenAmplitude5 end
-    QuantumPropagators.Controls.getcontrols(::BrokenAmplitude5) = (ϵ,)
+    QuantumPropagators.Controls.get_controls(::BrokenAmplitude5) = (ϵ,)
     QuantumPropagators.Controls.evalcontrols(::BrokenAmplitude5, _...) =
         error("Not implemented")
     @test_throws ErrorException("Not implemented") begin
@@ -91,9 +91,9 @@ end
     end
 
     struct BrokenAmplitude6 end
-    QuantumPropagators.Controls.getcontrols(::BrokenAmplitude6) = (ϵ,)
+    QuantumPropagators.Controls.get_controls(::BrokenAmplitude6) = (ϵ,)
     QuantumPropagators.Controls.evalcontrols(::BrokenAmplitude6, _...) = 1.0
-    QuantumControlBase.getcontrolderiv(::BrokenAmplitude6, _) = error("Not implemented")
+    QuantumControlBase.get_control_deriv(::BrokenAmplitude6, _) = error("Not implemented")
     @test_throws ErrorException("Invalid control amplitude") begin
         with_logger(test_logger) do
             @info "BrokenAmplitude6"
@@ -102,7 +102,7 @@ end
     end
 
     struct BrokenAmplitude7 end
-    QuantumPropagators.Controls.getcontrols(::BrokenAmplitude7) = (ϵ,)
+    QuantumPropagators.Controls.get_controls(::BrokenAmplitude7) = (ϵ,)
     QuantumPropagators.Controls.evalcontrols(::BrokenAmplitude7, _...) = 1.0
     @test_throws ErrorException("Invalid control amplitude") begin
         with_logger(test_logger) do
@@ -140,7 +140,7 @@ end
     end
 
     struct BrokenGenerator end
-    QuantumPropagators.Controls.getcontrols(::BrokenGenerator) = (ϵ₁, ϵ₂)
+    QuantumPropagators.Controls.get_controls(::BrokenGenerator) = (ϵ₁, ϵ₂)
     @test_throws ErrorException("Invalid generator") begin
         with_logger(test_logger) do
             @info "BrokenGenerator"
@@ -149,7 +149,7 @@ end
     end
 
     struct BrokenGenerator2 end
-    QuantumPropagators.Controls.getcontrols(::BrokenGenerator2) = (ϵ₁, ϵ₂)
+    QuantumPropagators.Controls.get_controls(::BrokenGenerator2) = (ϵ₁, ϵ₂)
     QuantumPropagators.Controls.evalcontrols(::BrokenGenerator2, _...) = nothing
     @test_throws ErrorException("Invalid generator") begin
         with_logger(test_logger) do
@@ -159,9 +159,9 @@ end
     end
 
     struct BrokenGenerator3 end
-    QuantumPropagators.Controls.getcontrols(::BrokenGenerator3) = (ϵ₁, ϵ₂)
+    QuantumPropagators.Controls.get_controls(::BrokenGenerator3) = (ϵ₁, ϵ₂)
     QuantumPropagators.Controls.evalcontrols(::BrokenGenerator3, _...) = H₀
-    QuantumControlBase.getcontrolderiv(::BrokenGenerator3, _) =
+    QuantumControlBase.get_control_deriv(::BrokenGenerator3, _) =
         random_hermitian_matrix(5, 1.0)
     @test_throws ErrorException("Invalid generator") begin
         with_logger(test_logger) do
@@ -171,9 +171,9 @@ end
     end
 
     struct BrokenGenerator4 end
-    QuantumPropagators.Controls.getcontrols(::BrokenGenerator4) = (ϵ₁, ϵ₂)
+    QuantumPropagators.Controls.get_controls(::BrokenGenerator4) = (ϵ₁, ϵ₂)
     QuantumPropagators.Controls.evalcontrols(::BrokenGenerator4, _...) = H₀
-    QuantumControlBase.getcontrolderiv(::BrokenGenerator4, _) = nothing
+    QuantumControlBase.get_control_deriv(::BrokenGenerator4, _) = nothing
     @test_throws ErrorException("Invalid generator") begin
         with_logger(test_logger) do
             @info "BrokenGenerator4"
@@ -182,7 +182,7 @@ end
     end
 
     struct BrokenGenerator5 end
-    QuantumPropagators.Controls.getcontrols(::BrokenGenerator5) = (ϵ₁, ϵ₂)
+    QuantumPropagators.Controls.get_controls(::BrokenGenerator5) = (ϵ₁, ϵ₂)
     QuantumPropagators.Controls.evalcontrols(::BrokenGenerator5, _...) =
         error("Not Implemented")
     @test_throws ErrorException("Not Implemented") begin
@@ -193,7 +193,7 @@ end
     end
 
     struct BrokenGenerator6 end
-    QuantumPropagators.Controls.getcontrols(::BrokenGenerator6) = error("Not Implemented")
+    QuantumPropagators.Controls.get_controls(::BrokenGenerator6) = error("Not Implemented")
     @test_throws ErrorException("Not Implemented") begin
         with_logger(test_logger) do
             @info "BrokenGenerator6"
@@ -202,9 +202,9 @@ end
     end
 
     struct BrokenGenerator7 end
-    QuantumPropagators.Controls.getcontrols(::BrokenGenerator7) = (ϵ₁, ϵ₂)
+    QuantumPropagators.Controls.get_controls(::BrokenGenerator7) = (ϵ₁, ϵ₂)
     QuantumPropagators.Controls.evalcontrols(::BrokenGenerator7, _...) = H₀
-    QuantumControlBase.getcontrolderiv(::BrokenGenerator7, control) =
+    QuantumControlBase.get_control_deriv(::BrokenGenerator7, control) =
         error("Not Implemented")
     @test_throws ErrorException("Invalid generator") begin
         with_logger(test_logger) do


### PR DESCRIPTION
* `initprop` → `init_prop`
* `propstep!` → `prop_step!`
* `reinitprop!` → `reinit_prop!`
* `getcontrolderiv` → `get_control_deriv`
* `getcontrolderivs` → `get_control_derivs`
* `getcontrols` → `get_controls`

The old names were based on the [Julia Style Guide](https://docs.julialang.org/en/v1/manual/style-guide/#Use-naming-conventions-consistent-with-Julia-base/) recommendation to name methods with "multiple words squashed together". I've come to regard this as a very bad idea. To quote the [JuMP style guide](https://jump.dev/JuMP.jl/stable/developers/style/), "This convention creates the potential for unnecessary bikeshedding and also forces the user to recall the presence/absence of an underscore, e.g., "was that argument named basename or base_name?". For consistency, always use underscores in variable names and function names to separate words.