### PR TITLE
Refactor and make `set_state!` private

### DIFF
--- a/docs/generate_api.jl
+++ b/docs/generate_api.jl
@@ -79,7 +79,10 @@ At a slightly lower level, propagation of quantum states in encapsulated by [The
 * [`init_prop`](@ref) — Initialize a `propagator` object, which is of some concrete (method-dependent) sub-type of [`AbstractPropagator`](@ref QuantumPropagators.AbstractPropagator)
 * [`reinit_prop!`](@ref) — Re-initialize the `propagator`
 * [`prop_step!`](@ref) — Advance the `propagator`  by a single time step forward or backward
-* [`set_state!`](@ref) — Mutate the current quantum `state` of the `propagator`.
+
+In some cases, the ability to mutate the propagator after each propagation step can be useful. This can be achieved with the following private methods:
+
+* [`set_state!`](@ref QuantumPropagators.set_state!) — Mutate the current quantum `state` of the `propagator` (**not exported**)
 * [`set_t!`](@ref QuantumPropagators.set_t!) — Mutate the current time of the `propagator` (**not exported**)
 
 The dynamics of a quantum state are determined by a time-dependent dynamical generator (a Hamiltonian or Liouvillian).
@@ -88,14 +91,9 @@ The `QuantumPropagators` package re-exports the two main initialization routines
 * [`hamiltonian`](@ref) — Construct a time-dependent generator for a propagation in Hilbert space under the Schrödinger equation
 * [`liouvillian`](@ref) — Construct a time-dependent generator for a propagation in Liouville space under the master equation in Lindblad form
 
-To support the `storage` feature of [`propagate`](@ref), the following routines from [the `Storage` sub-module](@ref QuantumPropagatorsStorageAPI) are re-exported in `QuantumPropagators`:
+To set up the time-dependent control fields in a Hamiltonian, methods from the submodules [`QuantumPropagators.Controls`](@ref QuantumPropagatorsControlsAPI), [`QuantumPropagators.Shapes`](@ref QuantumPropagatorsShapesAPI), and [`QuantumPropagators.Amplitudes`](@ref QuantumPropagatorsAmplitudesAPI) can be used.
 
-* [`init_storage`](@ref) – Create a storage array for propagated states or expectation values
-* [`write_to_storage!`](@ref) – Place data into storage
-* [`get_from_storage!`](@ref) – Obtain data from storage (in-place)
-
-The above list of methods constitutes the entire *public* interface of `QuantumPropagators`. At the lowest level, further functionality is provided by sub-modules like [`QuantumPropagators.Cheby`](@ref QuantumPropagatorsChebyAPI), which defines a standalone API specifically for the Chebychev propagation method.
-
+The above constitutes the main interface of `QuantumPropagators`. At the lowest level, further functionality is provided by sub-modules like [`QuantumPropagators.Cheby`](@ref QuantumPropagatorsChebyAPI), which defines a standalone API specifically for the Chebychev propagation method.
 """ * summarize_submodules(QuantumPropagators)
 
 
@@ -226,10 +224,7 @@ open(outfile, "w") do out
         QuantumPropagators.Storage,
         """The following routines allow to manage and extend storage arrays
         `storage` parameter in [`propagate`](@ref). See [Storage of states or
-        expectation values](@ref) for more details. Note that the high-level
-        routines [`init_storage`](@ref), [`write_to_storage!`](@ref), and
-        [`get_from_storage!`](@ref) are also re-exported in the top-level
-        [QuantumPropagators](@ref QuantumPropagatorsAPI) directly.
+        expectation values](@ref) for more details.
         """
     )
     write_module_api(

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -91,7 +91,7 @@ which differs from most textbooks by a factor of ``i``, but has the benefit that
 
 In the above example, the "generator" `H` that is the second argument to [`propagate`](@ref) was a simple static operator. In general, we will want time-dependent Hamiltonians or Liouvillians. The standard way to initialize a time-dependent Hamiltonian is via the [`hamiltonian`](@ref) function, e.g., as  `hamiltonian(Ĥ₀, (Ĥ₁, ϵ₁), (Ĥ₂, ϵ₂))`. The `Ĥ₀`, `Ĥ₁`, and `Ĥ₂` are static operators, and `ϵ₁` and `ϵ₂` are control fields, typically functions of time `t`. For piecewise-constant propagators, `ϵ₁` nad `ϵ₂` may also be an array of amplitude values appropriate to the time grid `tlist`. The tuple-syntax for the time-dependent terms is inspired by [QuTiP](https://qutip.org/docs/latest/guide/dynamics/dynamics-time.html).
 
-Generally, the `generator`, or the operators/controls inside the tuples can be a arbitrary objects, as long as some relevant methods are implemented for these objects, see the full section on [Dynamic Generators](@ref).
+Generally, the `generator`, or the operators/controls inside the tuples can be a arbitrary objects, as long as some relevant methods are implemented for these objects, see the full section on [Dynamical Generators](@ref).
 
 Open quantum systems are handled identically to closed quantum system, except that Hamiltonian operator are replaced by Liouvillian super-operators. For any system of non-trivial Hilbert space dimension, all (super-)operators should be sparse matrices.
 

--- a/docs/src/storage.md
+++ b/docs/src/storage.md
@@ -1,6 +1,6 @@
 # Storage of states or expectation values
 
-The [`propagate`](@ref) routine allows the storage of data for every point of the time grid.  This is done by passing it a `storage` object created with [`init_storage`](@ref), or simply `storage=true` in order to create the appropriate storage automatically.
+The [`propagate`](@ref) routine allows the storage of data for every point of the time grid.  This is done by passing it a `storage` object created with [`QuantumPropagators.Storage.init_storage`](@ref), or simply `storage=true` in order to create the appropriate storage automatically.
 
 By default, the `storage` will be used to store the propagated states at each point in time. More generally, what goes into `storage` can be customized via the `observables` parameter of [`propagate`](@ref).
 
@@ -9,7 +9,7 @@ After each propagation step, with a propagate state at time slot `i`,
 * [`QuantumPropagators.Storage.map_observables`](@ref) generates `data` from the propagated state
 * [`QuantumPropagators.Storage.write_to_storage!`](@ref) places that `data` into `storage` for time slot `i`
 
-After [`propagate`](@ref) returns, the [`get_from_storage!`](@ref) routine can be used to extract data from any time slot. This interface hides the internal memory organization of `storage`, which is set up by [`init_storage`](@ref) based on the type of `state` and the given `observables`. This system can can extended with multiple dispatch, allowing to optimize the `storage` for custom data types. Obviously, [`init_storage`](@ref), [`map_observables`](@ref QuantumPropagators.Storage.map_observables), [`write_to_storage!`](@ref), and [`get_from_storage!`](@ref) must all be consistent.
+After [`propagate`](@ref) returns, the [`QuantumPropagators.Storage.get_from_storage!`](@ref) routine can be used to extract data from any time slot. This interface hides the internal memory organization of `storage`, which is set up by [`init_storage`](@ref QuantumPropagators.Storage.init_storage) based on the type of `state` and the given `observables`. This system can can extended with multiple dispatch, allowing to optimize the `storage` for custom data types. Obviously, [`init_storage`](@ref QuantumPropagators.Storage.init_storage), [`map_observables`](@ref QuantumPropagators.Storage.map_observables), [`write_to_storage!`](@ref QuantumPropagators.Storage.write_to_storage!), and [`get_from_storage!`](@ref QuantumPropagators.Storage.get_from_storage!) must all be consistent.
 
 The default implementation of these routine uses either a standard Vector or a Matrix as `storage`.
 

--- a/src/QuantumPropagators.jl
+++ b/src/QuantumPropagators.jl
@@ -8,9 +8,6 @@ include("./expprop.jl")   # submodule ExpProp
 
 include("./storage.jl")   # submodule Storage
 
-using .Storage
-export init_storage, write_to_storage!, get_from_storage!
-
 include("./shapes.jl")  # submodule Shapes
 
 include("./controls.jl")  # submodule Controls
@@ -24,8 +21,8 @@ using .Generators
 export liouvillian, hamiltonian
 
 include("./propagator.jl")
-export init_prop, reinit_prop!, prop_step!, set_state!
-# not exported: set_t!, choose_propmethod
+export init_prop, reinit_prop!, prop_step!
+# not exported: set_t!, set_state!, choose_propmethod
 
 include("./pwc_utils.jl")
 include("./cheby_propagator.jl")

--- a/src/propagate.jl
+++ b/src/propagate.jl
@@ -1,6 +1,8 @@
 using LinearAlgebra
 using ProgressMeter
 
+using .Storage: init_storage, write_to_storage!
+
 
 # Return `true` if `H` has only real eigenvalues, `false` if `H` has
 # eigenvalues with a non-zero imaginary part, and `nothing` if field of the
@@ -93,9 +95,9 @@ QuantumPropagators.Cheby.cheby!)) only support a uniform time grid.
 
 If `storage` is given as an Array, it will be filled with data determined by
 the `observables`. The default "observable" results in the propagated states at
-every point in time being stored.
-The `storage` array should be created with [`init_storage`](@ref). See its
-documentation for details.
+every point in time being stored.  The `storage` array should be created with
+[`QuantumControl.Storage.init_storage`](@ref init_storage). See its documentation for
+details.
 
 The `storage` parameter may also be given as `true`, and a new storage array
 will be created internally with [`init_storage`](@ref) and returned instead of
@@ -179,11 +181,11 @@ function propagate(
     if backward
         intervals = Iterators.reverse(intervals)
         if storage ≠ nothing
-            Storage.write_to_storage!(storage, lastindex(tlist), state, observables)
+            write_to_storage!(storage, lastindex(tlist), state, observables)
         end
     else
         if storage ≠ nothing
-            Storage.write_to_storage!(storage, 1, state, observables)
+            write_to_storage!(storage, 1, state, observables)
         end
     end
 
@@ -201,7 +203,7 @@ function propagate(
     for (i, t_end) in intervals
         prop_step!(propagator)
         if storage ≠ nothing
-            Storage.write_to_storage!(
+            write_to_storage!(
                 storage,
                 i + (backward ? 0 : 1),
                 propagator.state,

--- a/src/propagator.jl
+++ b/src/propagator.jl
@@ -32,9 +32,9 @@ should be considered private.
   backward) on the time grid.
 * [`set_state!`](@ref) — safely mutate the current quantum `state` of the
   propagation. Note that directly mutating the `state` property is not safe.
-  However, `Ψ = propagator.state; mutate!(Ψ), set_state!(propagator, Ψ)` is
-  guaranteed to be safe and efficient for both in-place and not-in-place
-  propagators.
+  However, `Ψ = propagator.state; foo_mutate!(Ψ), set_state!(propagator, Ψ)`
+  for some mutating function `foo_mutate!` is guaranteed to be safe and
+  efficient for both in-place and not-in-place propagators.
 * [`set_t!`](@ref QuantumPropagators.set_t!) — safely mutate the current time
   (`propagator.t`), snapping to the values of `tlist`.
 
@@ -373,16 +373,17 @@ after a call to [`prop_step!`](@ref), the following pattern is recommended:
 
 ```
 Ψ = propagator.state
-mutate!(Ψ)
+foo_mutate!(Ψ)
 set_state!(propagator, Ψ)
 ```
 
-This is guaranteed to work efficiently both for in-place and not-in-place
-propagators, without incurring unnecessary copies.
+where `foo_mutate!` is some function that mutates `Ψ`.  This is guaranteed to
+work efficiently both for in-place and not-in-place propagators, without
+incurring unnecessary copies.
 
 !!! warning
     ```
-    mutate!(propagator.state)
+    foo_mutate!(propagator.state)
     ```
 
     by itself is not a safe operation. Always follow it by

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -30,6 +30,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Term = "22787eb5-b846-44ae-b979-8e399b8463ab"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TwoQubitWeylChamber = "cad078a0-0012-46f4-b55e-a945d44e115b"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 

--- a/test/init.jl
+++ b/test/init.jl
@@ -3,7 +3,7 @@ using Revise
 using Plots
 unicodeplots()
 using JuliaFormatter
-using QuantumControlBase.TestUtils: test, show_coverage, generate_coverage_html
+using QuantumControlTestUtils: test, show_coverage, generate_coverage_html
 using LiveServer: LiveServer, serve, servedocs as _servedocs
 using Term
 include(joinpath(@__DIR__, "clean.jl"))

--- a/test/test_controls.jl
+++ b/test/test_controls.jl
@@ -5,14 +5,14 @@ using QuantumPropagators
 using QuantumPropagators.Generators
 using QuantumPropagators.Controls
 using QuantumPropagators: Generator, Operator
-using QuantumControlBase.TestUtils: random_hermitian_matrix
+using QuantumControlTestUtils.RandomObjects: random_matrix
 
 
 @testset "Simple get_controls" begin
 
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
-    H₂ = random_hermitian_matrix(5, 1.0)
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
+    H₂ = random_matrix(5; hermitian=true)
 
     @test length(get_controls(H₀)) == 0
 
@@ -36,9 +36,9 @@ end
 
 
 @testset "Tuple evaluate" begin
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
-    H₂ = random_hermitian_matrix(5, 1.0)
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
+    H₂ = random_matrix(5; hermitian=true)
     ϵ₁(t) = 1.0
     ϵ₂(t) = 1.0
     H = (H₀, (H₁, ϵ₁), (H₂, ϵ₂))
@@ -89,9 +89,9 @@ end
 
 @testset "Generator evaluate" begin
 
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
-    H₂ = random_hermitian_matrix(5, 1.0)
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
+    H₂ = random_matrix(5; hermitian=true)
     ϵ₁ = t -> 1.0
     ϵ₂ = t -> 1.0
 
@@ -149,9 +149,9 @@ end
 
 @testset "vector controls substitution" begin
 
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
-    H₂ = random_hermitian_matrix(5, 1.0)
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
+    H₂ = random_matrix(5; hermitian=true)
     ϵ₁ = [0.0, 0.1, 0.5, 0.1, 0.0]
     ϵ₂ = [0.0, 0.1, 0.5, 0.1, 0.0]
 
@@ -180,9 +180,9 @@ end
 
 
 @testset "Tuple substitute" begin
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
-    H₂ = random_hermitian_matrix(5, 1.0)
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
+    H₂ = random_matrix(5; hermitian=true)
     ϵ₁ = t -> 1.0
     ϵ₂ = t -> 1.0
     H = (H₀, (H₁, ϵ₁), (H₂, ϵ₂))
@@ -205,9 +205,9 @@ end
 
 @testset "Generator substitute" begin
 
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
-    H₂ = random_hermitian_matrix(5, 1.0)
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
+    H₂ = random_matrix(5; hermitian=true)
     ϵ₁ = t -> 1.0
     ϵ₂ = t -> 1.0
     H = hamiltonian(H₀, (H₁, ϵ₁), (H₂, ϵ₂))
@@ -250,9 +250,9 @@ end
 
 @testset "Nonlinear substitute" begin
 
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
-    H₂ = random_hermitian_matrix(5, 1.0)
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
+    H₂ = random_matrix(5; hermitian=true)
     ϵ₁ = t -> 1.0
     ϵ₂ = t -> 1.0
 

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -5,8 +5,8 @@ using LinearAlgebra
 using QuantumPropagators
 using QuantumPropagators: Generator, Operator
 using QuantumControlBase
-using QuantumControlBase.TestUtils:
-    random_hermitian_matrix, random_real_matrix, random_state_vector, QuantumTestLogger
+using QuantumControlTestUtils.RandomObjects: random_matrix, random_state_vector
+using QuantumControlTestUtils: QuantumTestLogger
 
 _OT(::Generator{OT,AT}) where {OT,AT} = OT
 _AT(::Generator{OT,AT}) where {OT,AT} = AT
@@ -17,9 +17,9 @@ _CT(::Operator{OT,CT}) where {OT,CT}  = CT
 
 @testset "Operator interface" begin
 
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
-    H₂ = random_hermitian_matrix(5, 1.0)
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
+    H₂ = random_matrix(5; hermitian=true)
     Ψ = random_state_vector(5)
 
     H = Operator([H₀, H₁, H₂], [1.1, 2.1])
@@ -116,10 +116,10 @@ end
 
 @testset "Generator interface" begin
 
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
     ϵ₁ = t -> 1.0
-    H₂ = random_hermitian_matrix(5, 1.0)
+    H₂ = random_matrix(5; hermitian=true)
     ϵ₂ = t -> 1.0
 
     H = hamiltonian(H₀)
@@ -162,7 +162,7 @@ end
     QuantumPropagators.Controls.get_controls(::BrokenGenerator3) = (ϵ₁, ϵ₂)
     QuantumPropagators.Controls.evalcontrols(::BrokenGenerator3, _...) = H₀
     QuantumControlBase.get_control_deriv(::BrokenGenerator3, _) =
-        random_hermitian_matrix(5, 1.0)
+        random_matrix(5; hermitian=true)
     @test_throws ErrorException("Invalid generator") begin
         with_logger(test_logger) do
             @info "BrokenGenerator3"
@@ -220,10 +220,10 @@ end
 
 @testset "standard Hamiltonians" begin
 
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
     ϵ₁ = t -> 1.0
-    H₂ = random_hermitian_matrix(5, 1.0)
+    H₂ = random_matrix(5; hermitian=true)
     ϵ₂ = t -> 1.0
 
     H = hamiltonian(H₀)
@@ -291,7 +291,7 @@ end
 
 @testset "pathologial Hamiltonians" begin
 
-    H₀ = random_hermitian_matrix(5, 1.0)
+    H₀ = random_matrix(5; hermitian=true)
 
     @test_throws ErrorException("Generator has no terms") begin
         H = hamiltonian()
@@ -306,10 +306,10 @@ end
 
 @testset "vector control Hamiltonians" begin
 
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
     ϵ₁ = rand(10)
-    H₂ = random_hermitian_matrix(5, 1.0)
+    H₂ = random_matrix(5; hermitian=true)
     ϵ₂ = rand(10)
 
     H = hamiltonian(H₀, (H₁, ϵ₁), (H₂, ϵ₂))
@@ -324,11 +324,11 @@ end
 
 @testset "pathological Hamiltonians" begin
 
-    H₀_r = random_real_matrix(5, 1.0)
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
+    H₀_r = random_matrix(5; complex=false)
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
     ϵ₁ = t -> 1.0
-    H₂ = random_hermitian_matrix(5, 1.0)
+    H₂ = random_matrix(5; hermitian=true)
     ϵ₂ = t -> 1.0
     ϵ₂_v = rand(10)
 

--- a/test/test_liouvillian.jl
+++ b/test/test_liouvillian.jl
@@ -4,7 +4,7 @@ using QuantumPropagators.Generators
 using QuantumPropagators.Controls
 using LinearAlgebra
 using Distributions
-using QuantumControlBase.TestUtils
+using QuantumControlTestUtils.RandomObjects: random_matrix, random_state_vector
 using SparseArrays
 
 
@@ -66,8 +66,8 @@ end
 
     ketbra(i, j) = ket(i) * bra(j)
 
-    Ĥ₀ = random_hermitian_matrix(N, 1)
-    Ĥ₁ = random_hermitian_matrix(N, 0.1)
+    Ĥ₀ = random_matrix(N; hermitian=true, spectral_radius=1)
+    Ĥ₁ = random_matrix(N; hermitian=true, spectral_radius=0.1)
 
     ϵ(t) = 1.0
     H = (Ĥ₀, (Ĥ₁, ϵ))

--- a/test/test_newton.jl
+++ b/test/test_newton.jl
@@ -2,7 +2,7 @@ using Test
 using LinearAlgebra
 using QuantumPropagators
 using QuantumPropagators.Newton
-using QuantumControlBase.TestUtils
+using QuantumControlTestUtils.RandomObjects: random_matrix, random_state_vector
 
 @testset "random Hermitian" begin
 
@@ -26,7 +26,7 @@ using QuantumControlBase.TestUtils
     dt = 0.5
 
     if SERIALIZATION < 2
-        H = random_hermitian_matrix(N, ρ)
+        H = random_matrix(N; spectral_radius=ρ, hermitian=true)
         Ψ₀ = random_state_vector(N)
     end
 
@@ -89,7 +89,7 @@ end
     dt = 0.5
 
     if SERIALIZATION < 2
-        H = random_complex_matrix(N, ρ)
+        H = random_matrix(N; spectral_radius=ρ)
         Ψ₀ = random_state_vector(N)
     end
 
@@ -141,12 +141,12 @@ end
     # Input
     N = 32
     ρ = 10  # approximate spectral radius
-    sparsity = 0.5
+    density = 0.5
 
     dt = 0.5
 
     if SERIALIZATION < 2
-        L = random_complex_sparse_matrix(N^2, ρ, sparsity)
+        L = random_matrix(N^2; spectral_radius=ρ, density)
         Ψ₀ = random_state_vector(N)
         ρ₀ = reshape(Ψ₀ * Ψ₀', :)
     end

--- a/test/test_operator_linalg.jl
+++ b/test/test_operator_linalg.jl
@@ -1,15 +1,15 @@
 using Test
 using LinearAlgebra
-using QuantumControlBase.TestUtils: random_hermitian_matrix, random_state_vector
+using QuantumControlTestUtils.RandomObjects: random_matrix, random_state_vector
 
 using QuantumPropagators: Generator, Operator, ScaledOperator
 
 
 @testset "Operator mul!" begin
 
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
-    H₂ = random_hermitian_matrix(5, 1.0)
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
+    H₂ = random_matrix(5; hermitian=true)
 
     Op = Operator([H₀, H₁, H₂], [2.1, 1.1])
     H = H₀ + 2.1 * H₁ + 1.1 * H₂
@@ -43,9 +43,9 @@ end
 
 @testset "Operator copy" begin
 
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
-    H₂ = random_hermitian_matrix(5, 1.0)
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
+    H₂ = random_matrix(5; hermitian=true)
 
     Op = Operator([H₀, H₁, H₂], [2.1, 1.1])
     Op2 = copy(Op)
@@ -74,9 +74,9 @@ end
 
 @testset "Operator array conversion" begin
 
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
-    H₂ = random_hermitian_matrix(5, 1.0)
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
+    H₂ = random_matrix(5; hermitian=true)
 
     Op = Operator([H₀, H₁, H₂], [2.1, 1.1])
     H = H₀ + 2.1 * H₁ + 1.1 * H₂
@@ -128,9 +128,9 @@ end
 
 @testset "Operator dot" begin
 
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
-    H₂ = random_hermitian_matrix(5, 1.0)
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
+    H₂ = random_matrix(5; hermitian=true)
 
     Op = Operator([H₀, H₁, H₂], [2.1, 1.1])
     H = H₀ + 2.1 * H₁ + 1.1 * H₂
@@ -147,9 +147,9 @@ end
 
 @testset "ScaledOperator mul!" begin
 
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
-    H₂ = random_hermitian_matrix(5, 1.0)
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
+    H₂ = random_matrix(5; hermitian=true)
 
     @test norm(Array(ScaledOperator(0.5, H₀)) - 0.5 * H₀) < 1e-12
 
@@ -191,9 +191,9 @@ end
 
 @testset "ScaledOperator dot" begin
 
-    H₀ = random_hermitian_matrix(5, 1.0)
-    H₁ = random_hermitian_matrix(5, 1.0)
-    H₂ = random_hermitian_matrix(5, 1.0)
+    H₀ = random_matrix(5; hermitian=true)
+    H₁ = random_matrix(5; hermitian=true)
+    H₂ = random_matrix(5; hermitian=true)
 
     Op = Operator([H₀, H₁, H₂], [2.1, 1.1]) * 0.5
     @test Op isa ScaledOperator

--- a/test/test_specrad.jl
+++ b/test/test_specrad.jl
@@ -4,7 +4,7 @@ using Test
 using LinearAlgebra
 using QuantumPropagators
 using QuantumPropagators.SpectralRange
-using QuantumControlBase.TestUtils
+using QuantumControlTestUtils.RandomObjects: random_matrix, random_state_vector
 
 
 @testset "Ritz values (non-Herm)" begin
@@ -13,7 +13,7 @@ using QuantumControlBase.TestUtils
 
     N = 1000
     ρ = 10  # spectral radius
-    X = random_complex_matrix(N, ρ)
+    X = random_matrix(N; spectral_radius=ρ)
     Ψ = random_state_vector(N)
     # a non_Hermitian X requires significantly more iterations to converge than
     # the default
@@ -45,7 +45,7 @@ end
 
     N = 1000
     ρ = 10  # spectral radius
-    H = random_hermitian_matrix(N, ρ)
+    H = random_matrix(N; spectral_radius=ρ, hermitian=true)
     Ψ = random_state_vector(N)
     # for a Hermitian H, lower default (cf. specrange) should be ok
     ritzvals = QuantumPropagators.SpectralRange.ritzvals(H, Ψ, 20, 60; prec=1e-3)
@@ -77,8 +77,8 @@ end
 
     N = 1000
     ρ = 10  # spectral radius
-    s = 0.1  # sparsity
-    H = random_hermitian_sparse_matrix(N, ρ, s)
+    density = 0.1
+    H = random_matrix(N; hermitian=true, spectral_radius=ρ, density)
 
     evals = eigvals(Array(H))
     SHOWVALS && @show evals[1], evals[end]


### PR DESCRIPTION
This now uses the external QuantumControlTestUtils instead of old code from QuantumControlBase for testing.

The `set_state!` function isn't typically useful for an enduser, and we want to keep the QuantumControl API as simple as possible.