### PR TITLE
Ensure copy in discretization routines

### DIFF
--- a/src/controls.jl
+++ b/src/controls.jl
@@ -31,9 +31,9 @@ for round-trips between [`discretize`](@ref) and
 [`discretize_on_midpoints`](@ref)  (constant controls on `tlist` may result in
 a zig-zag on the intervals of `tlist`).
 
-If `control` is a vector, it will be returned un-modified if it is of the same
-length as `tlist`. Otherwise, `control` must have one less value than `tlist`,
-and is assumed to be defined on the midpoins of `tlist`. In that case,
+If `control` is a vector, a copy of `control` will be returned if it is of the
+same length as `tlist`. Otherwise, `control` must have one less value than
+`tlist`, and is assumed to be defined on the midpoins of `tlist`. In that case,
 [`discretize`](@ref) acts as the inverse of [`discretize_on_midpoints`](@ref).
 See [`discretize_on_midpoints`](@ref) for how control values on `tlist` and
 control values on the intervals of `tlist` are related.
@@ -49,7 +49,7 @@ end
 
 function discretize(control::Vector, tlist)
     if length(control) == length(tlist)
-        return control
+        return copy(control)
     elseif length(control) == length(tlist) - 1
         # convert `control` on intervals to values on `tlist`
         # cf. pulse_onto_tlist in Python krotov package
@@ -135,8 +135,9 @@ midpoint values ``pᵢ = 2 c_{i} - p_{i-1}``.
     it is safe to modify *midpoint* values. Modifying the the values on the
     time grid directly on the other hand may accumulate discretization errors.
 
-If `control` is a vector of one less length than `tlist`, it will be returned
-unchanged, under the assumption that the input is already properly discretized.
+If `control` is a vector of one less length than `tlist`, a copy of `control`
+will be returned, under the assumption that the input is already properly
+discretized.
 
 If `control` is a function, the function will be directly evaluated at the
 midpoints marked as `x` in the above diagram..
@@ -147,7 +148,7 @@ end
 
 function discretize_on_midpoints(control::Vector, tlist)
     if length(control) == length(tlist) - 1
-        return control
+        return copy(control)
     elseif length(control) == length(tlist)
         vals = zeros(eltype(control), length(control) - 1)
         vals[1] = control[1]

--- a/test/test_discretization.jl
+++ b/test/test_discretization.jl
@@ -20,6 +20,9 @@ using QuantumPropagators.Shapes: blackman
 
     control_vals3 = discretize(control_func, tlist; via_midpoints=false)
 
+    control_vals4 = discretize(control_vals1, tlist)
+    pulse_vals3 = discretize_on_midpoints(pulse_vals1, tlist)
+
     # "controls' are on tlist, "pulses" are on intervals
     @test length(control_vals1) == length(control_vals2) == length(tlist)
     @test length(pulse_vals1) == length(pulse_vals2) == length(tlist) - 1
@@ -33,5 +36,11 @@ using QuantumPropagators.Shapes: blackman
     @test control_vals3[13] == control_func(tlist[13])
     @test control_vals1[13] ≠ control_func(tlist[13])
     @test 1e-3 < abs(control_vals1[13] - control_func(tlist[13])) < 1e-1
+
+    # discretizing vectors that are already discretized should return a copy
+    @test control_vals4 ≢ control_vals1
+    @test maximum(abs.(control_vals4 .- control_vals1)) < 1e-14
+    @test pulse_vals3 ≢ pulse_vals1
+    @test maximum(abs.(pulse_vals3 .- pulse_vals1)) < 1e-14
 
 end


### PR DESCRIPTION
The `discretize` and `discretize_on_midpoints` routines should not return the exact input array if the input is already correctly discretized. At least, they should make a copy. Doing so avoids the problem described in https://github.com/JuliaQuantumControl/Krotov.jl/issues/28