### PR TITLE
Allow for time-dependent observables

### DIFF
--- a/docs/generate_api.jl
+++ b/docs/generate_api.jl
@@ -223,8 +223,8 @@ open(outfile, "w") do out
         out,
         QuantumPropagators.Storage,
         """The following routines allow to manage and extend storage arrays
-        `storage` parameter in [`propagate`](@ref). See [Storage of states or
-        expectation values](@ref) for more details.
+        `storage` parameter in [`propagate`](@ref). See the discussion of
+        [Expectation Values](@ref) for more details.
         """
     )
     write_module_api(

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -38,7 +38,7 @@ makedocs(
         "Overview" => "overview.md",
         "Dynamical Generators" => "generators.md",
         "Propagation Methods" => "methods.md",
-        "Storage" => "storage.md",
+        "Expectation Values" => "storage.md",
         hide("Examples" => "examples/index.md", [
         # "Example 1" => joinpath("examples", "1.md"),
         # "Example 2" => joinpath("examples", "2.md"),

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -58,7 +58,7 @@ The `storage` parameter provides a powerful way to obtain arbitrary dynamic quan
 * If given a pre-allocated storage array, fill it with the propagated states at each point in time, and return the final state.
 * If given in combination with `observables`, put arbitrary "observable" data derived from the propagated states in the storage array.
 
-See [Storage of states or expectation values](@ref) for details.
+See the discussion of [Expectation Values](@ref) for details.
 
 
 ## Propagation methods
@@ -136,7 +136,7 @@ t = 0.5π
 
 ## Backward propagation
 
-When [`propagate`](@ref) or [`init_prop`](@ref) are called with `backward=true`, the propagation is initialized to run backward. The initial state is then defined at `propagator.t == tlist[end]` and each [`prop_step!`](@ref) moves to the previous point in `tlist`. The equation of motion is the Schrödinger or Liouville equation with a negative $dt$. Note that the propagation uses the `generator` as it is defined: no automatic adjoint will be taken.
+When [`propagate`](@ref) or [`init_prop`](@ref) are called with `backward=true`, the propagation is initialized to run backward. The initial state is then defined at `propagator.t == tlist[end]` and each [`prop_step!`](@ref) moves to the previous point in `tlist`. The equation of motion is the Schrödinger or Liouville equation with a negative $dt$. For a Hermitian `generator`, doing a forward propagation followed by a backward propagation will recover the initial state. For a non-Hermitian `generator`, this no longer holds. Note that in optimal control methods such as GRAPE or Krotov's method, obtaining gradients involves a "backward propagation with the adjoint generator" (when the generator is non-Hermitian and adjoint/non-adjoint makes a difference). The [`propagate`](@ref) routine with `backward=true` will not automatically take this adjoint of the `generator`; instead, the adjoint generator must be passed explicitly.
 
 
 ## Connection to DifferentialEquations.jl

--- a/docs/src/storage.md
+++ b/docs/src/storage.md
@@ -1,4 +1,4 @@
-# Storage of states or expectation values
+# Expectation Values
 
 The [`propagate`](@ref) routine allows the storage of data for every point of the time grid.  This is done by passing it a `storage` object created with [`QuantumPropagators.Storage.init_storage`](@ref), or simply `storage=true` in order to create the appropriate storage automatically.
 
@@ -9,7 +9,7 @@ After each propagation step, with a propagate state at time slot `i`,
 * [`QuantumPropagators.Storage.map_observables`](@ref) generates `data` from the propagated state
 * [`QuantumPropagators.Storage.write_to_storage!`](@ref) places that `data` into `storage` for time slot `i`
 
-After [`propagate`](@ref) returns, the [`QuantumPropagators.Storage.get_from_storage!`](@ref) routine can be used to extract data from any time slot. This interface hides the internal memory organization of `storage`, which is set up by [`init_storage`](@ref QuantumPropagators.Storage.init_storage) based on the type of `state` and the given `observables`. This system can can extended with multiple dispatch, allowing to optimize the `storage` for custom data types. Obviously, [`init_storage`](@ref QuantumPropagators.Storage.init_storage), [`map_observables`](@ref QuantumPropagators.Storage.map_observables), [`write_to_storage!`](@ref QuantumPropagators.Storage.write_to_storage!), and [`get_from_storage!`](@ref QuantumPropagators.Storage.get_from_storage!) must all be consistent.
+After [`propagate`](@ref) returns, the [`QuantumPropagators.Storage.get_from_storage!`](@ref) routine can be used to extract data from any time slot. This interface hides the internal memory organization of `storage`, which is set up by [`init_storage`](@ref QuantumPropagators.Storage.init_storage) based on the type of `state` and the given `observables`. This system can be extended with multiple dispatch, allowing to optimize the `storage` for custom data types. Obviously, [`init_storage`](@ref QuantumPropagators.Storage.init_storage), [`map_observables`](@ref QuantumPropagators.Storage.map_observables), [`write_to_storage!`](@ref QuantumPropagators.Storage.write_to_storage!), and [`get_from_storage!`](@ref QuantumPropagators.Storage.get_from_storage!) must all be consistent.
 
 The default implementation of these routine uses either a standard Vector or a Matrix as `storage`.
 
@@ -29,15 +29,16 @@ vector `[⟨Ô₁⟩, ⟨Ô₂A]⟩]` at time slot `i`. Alternatively, `storag
 
 Usually, the `observables` should be functions acting on the `state`, but [`map_observables`](@ref QuantumPropagators.Storage.map_observables) can be extended to other types of observables as well. For example, the situation were `state` is a vector and the `observables` are matrices is also supported; if  `Ô₁`, `Ô₂` are matrices,
 ~~~julia
-observables=(Ô₁, Ô)
+observables=(Ô₁, Ô₂)
 ~~~
 would have the same result of storing the expectation values of those two operators.
 
-The `observables` are not required to yield real values: the term "observables"
+The `observables` are not required to yield real values: the term "observable"
 is used very loosely here. We could directly calculate, e.g., the complex
-amplitude α of a coherent state in quantum optics, the number of levels with
-non-zero population (as an integer), or the propagated state transformed from a
-moving frame to a lab frame.
+amplitude α of a coherent state in quantum optics, or the number of levels with
+non-zero population (as an integer).
+
+It is possible to have time-dependent "observables", for example, to store "lab-frame" states from a propagation in a (time-dependent) [rotating frame](https://en.wikipedia.org/wiki/Rotating-wave_approximation). This is supported by default by passing a function with the three arguments `state`, `tlist`, `i` as an observable, where `state` is defined to be at time `tlist[i]`.
 
 If there are multiple observables that return data of different types, by default `storage` will be a Vector that contains tuples with the result for each observable. For example, with
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,11 @@ using SafeTestsets
         include("test_propagate.jl")
     end
 
+    print("\n* Time-dependent observables (test_timedependent_observables.jl):")
+    @time @safetestset "Time-dependent observables" begin
+        include("test_timedependent_observables.jl")
+    end
+
     print("\n")
 
 end;

--- a/test/test_timedependent_observables.jl
+++ b/test/test_timedependent_observables.jl
@@ -1,0 +1,102 @@
+using Test
+using LinearAlgebra
+using StaticArrays
+using QuantumPropagators: propagate
+#using QuantumPropagators.Storage: init_storage, get_from_storage!
+
+@testset "TLS Lab Frame" begin
+
+    𝕚 = 1im
+    ≈(a, b) = isapprox(a, b; atol=1e-12)
+    ket(α, β) = SVector{2}(ComplexF64[α, β])
+
+    Ψ₀ = ket(1, 0)
+    Ω = 1
+    Ĥ = SMatrix{2,2}([0 -Ω/2; -Ω/2 0])
+    ω_l = 0.5  # rotating frame frequency
+
+    σ̂_y = [
+        0  -𝕚
+        𝕚   0
+    ]
+
+    tlist = collect(range(0, 1.5π, length=101)) # 3π/2 pulse
+
+    # states in rotating frame
+
+    states = propagate(Ψ₀, Ĥ, tlist; storage=true, method=:expprop, inplace=false)
+    g(t) = cos(Ω * t / 2)
+    e(t) = 𝕚 * sin(Ω * t / 2)
+    for i in eachindex(tlist)
+        Ψ = states[i]
+        t = tlist[i]
+        @test norm(Ψ - ket(g(t), e(t))) ≈ 0.0
+    end
+
+
+    # expectation values in rotating frame
+
+    expvals = propagate(
+        Ψ₀,
+        Ĥ,
+        tlist;
+        observables=(σ̂_y,),
+        storage=true,
+        method=:expprop,
+        inplace=false
+    )
+    @test norm(expvals .- [sin(Ω * t) for t ∈ tlist]) ≈ 0.0
+
+
+    # states in lab frame
+
+    Û(t) = SMatrix{2,2}([   # lab frame to rotating frame
+        1  0
+        0  exp(-𝕚 * ω_l * t)
+    ])
+
+    Û⁺(t) = SMatrix{2,2}([  # rotating frame to lab frame
+        1  0
+        0  exp(𝕚 * ω_l * t)
+    ])
+
+    to_lab(Ψ, tlist, i) = Û⁺(tlist[i]) * Ψ
+    @show typeof(to_lab(ket(0, 1), tlist, lastindex(tlist)))
+    states_lab = propagate(
+        Ψ₀,
+        Ĥ,
+        tlist;
+        observables=(to_lab,),
+        storage=true,
+        method=:expprop,
+        inplace=false
+    )
+    @show typeof(states_lab)
+    @show states_lab
+    for (Ψ_lab, Ψ_rot, t) in zip(states_lab, states, tlist)
+        @test norm(Ψ_lab - ket(cos(Ω * t / 2), 𝕚 * exp(𝕚 * ω_l * t) * sin(Ω * t / 2))) ≈ 0.0
+        @test norm(Û(t) * Ψ_lab - Ψ_rot) ≈ 0.0
+    end
+
+
+    # expectation values in lab frame
+
+    function σ̄_y_lab(Ψ_rot, tlist, i)
+        t = tlist[i]
+        Ψ_lab = Û⁺(t) * Ψ_rot
+        return dot(Ψ_lab, σ̂_y, Ψ_lab)
+    end
+
+    expvals_lab = propagate(
+        Ψ₀,
+        Ĥ,
+        tlist;
+        observables=(σ̄_y_lab,),
+        storage=true,
+        method=:expprop,
+        inplace=false
+    )
+
+    @test norm(expvals_lab .- [sin(Ω * t) * cos(ω_l * t) for t ∈ tlist]) ≈ 0.0
+
+end

--- a/test/test_timedependent_observables_notes.ipynb
+++ b/test/test_timedependent_observables_notes.ipynb
@@ -1,0 +1,1008 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e8b420fc",
+   "metadata": {},
+   "source": [
+    "# Rabi Cycling in the Two-Level-System — Lab and Rotating Frame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "099e6f02",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.333081Z",
+     "start_time": "2023-04-04T18:51:50.078426Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import Function, symbols, sqrt, Eq, Abs, exp, cos, sin, Matrix, dsolve, solve"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "392d26c5",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.336465Z",
+     "start_time": "2023-04-04T18:51:50.334384Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from sympy import I as 𝕚"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "22151c90",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.339452Z",
+     "start_time": "2023-04-04T18:51:50.337254Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "g = Function('g')\n",
+    "e = Function('e')\n",
+    "t = symbols('t', positive=True)\n",
+    "Δ = 0#symbols('Delta', real=True)\n",
+    "Ω0 = symbols('Ω_0', real=True)\n",
+    "Ω = symbols('Omega', real=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b7ac0d90",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.447612Z",
+     "start_time": "2023-04-04T18:51:50.340331Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left[\\begin{matrix}0 & - \\frac{Ω_{0}}{2}\\\\- \\frac{Ω_{0}}{2} & 0\\end{matrix}\\right]$"
+      ],
+      "text/plain": [
+       "Matrix([\n",
+       "[     0, -Ω_0/2],\n",
+       "[-Ω_0/2,      0]])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Ĥ = Matrix([\n",
+    "    [  0  , -Ω0/2],\n",
+    "    [-Ω0/2,    Δ ]\n",
+    "])\n",
+    "Ĥ"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4d51a2cf",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.453025Z",
+     "start_time": "2023-04-04T18:51:50.449568Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "TDSE_system = [\n",
+    "    g(t).diff(t) + 𝕚 * (Ĥ[0,0] * g(t) + Ĥ[0,1] * e(t)),\n",
+    "    e(t).diff(t) + 𝕚 * (Ĥ[1,0]*  g(t) + Ĥ[1,1] * e(t)),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "74fa6ba2",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.575516Z",
+     "start_time": "2023-04-04T18:51:50.453863Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "sols_gen = dsolve(TDSE_system, [g(t), e(t)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a501c1d6",
+   "metadata": {},
+   "source": [
+    "Note that `dsolve` allows to specify boundary conditions, but the resulting expressions are hard to simply. We do better by solving for the integration constants \"manually\" later on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2718f04e",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.578816Z",
+     "start_time": "2023-04-04T18:51:50.576751Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "effective_rabi_freq = {\n",
+    "    Ω: sqrt(Δ**2 + Ω0**2)\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "75ee2c2a",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.583687Z",
+     "start_time": "2023-04-04T18:51:50.579784Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\Omega = \\left|{Ω_{0}}\\right|$"
+      ],
+      "text/plain": [
+       "Eq(Omega, Abs(Ω_0))"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Eq(Ω, effective_rabi_freq[Ω])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "79b723c4",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.586518Z",
+     "start_time": "2023-04-04T18:51:50.584742Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "find_Ω = {\n",
+    "    effective_rabi_freq[Ω]: Ω\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "b05f056e",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.591518Z",
+     "start_time": "2023-04-04T18:51:50.587800Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle g{\\left(t \\right)} = - C_{1} e^{- \\frac{i t Ω_{0}}{2}} + C_{2} e^{\\frac{i t Ω_{0}}{2}}$"
+      ],
+      "text/plain": [
+       "Eq(g(t), -C1*exp(-I*t*Ω_0/2) + C2*exp(I*t*Ω_0/2))"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sols_gen[0].subs(find_Ω)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "e8e0977b",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.596884Z",
+     "start_time": "2023-04-04T18:51:50.592648Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle e{\\left(t \\right)} = C_{1} e^{- \\frac{i t Ω_{0}}{2}} + C_{2} e^{\\frac{i t Ω_{0}}{2}}$"
+      ],
+      "text/plain": [
+       "Eq(e(t), C1*exp(-I*t*Ω_0/2) + C2*exp(I*t*Ω_0/2))"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sols_gen[1].subs(find_Ω).expand()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "394f4efd",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.599647Z",
+     "start_time": "2023-04-04T18:51:50.597777Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "boundary_conditions = {\n",
+    "    t: 0,\n",
+    "    g(t): 1,\n",
+    "    e(t) : 0,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "23be389b",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.602252Z",
+     "start_time": "2023-04-04T18:51:50.600485Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "find_Ω0sq = {\n",
+    "    Ω**2 - Δ**2: Ω0**2\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "be349bd8",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.608787Z",
+     "start_time": "2023-04-04T18:51:50.607085Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "C1, C2 = symbols(\"C1, C2\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "7d321d1e",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.623058Z",
+     "start_time": "2023-04-04T18:51:50.609795Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "_integration_constants = solve(\n",
+    "    [sol.subs(find_Ω).subs(boundary_conditions) for sol in sols_gen],\n",
+    "    [C1, C2]\n",
+    ")\n",
+    "integration_constants = {\n",
+    "    k: v.subs(find_Ω0sq)\n",
+    "    for (k, v) in _integration_constants.items()\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "894eeee2",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.627475Z",
+     "start_time": "2023-04-04T18:51:50.624030Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle C_{1} = - \\frac{1}{2}$"
+      ],
+      "text/plain": [
+       "Eq(C1, -1/2)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Eq(C1, integration_constants[C1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "851352b3",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.631965Z",
+     "start_time": "2023-04-04T18:51:50.628291Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle C_{2} = \\frac{1}{2}$"
+      ],
+      "text/plain": [
+       "Eq(C2, 1/2)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Eq(C2, integration_constants[C2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "339ee928",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.634635Z",
+     "start_time": "2023-04-04T18:51:50.632883Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "global_phase = exp(-𝕚 * Δ * t / 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "21dc5c9c",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.638038Z",
+     "start_time": "2023-04-04T18:51:50.635556Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def remove_global_phase(eq, global_phase=global_phase):\n",
+    "    return Eq(eq.lhs, eq.rhs * global_phase.conjugate())\n",
+    "\n",
+    "def restore_global_phase(eq, global_phase=global_phase):\n",
+    "    return Eq(eq.lhs, eq.rhs * global_phase)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "43fb88d4",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.640695Z",
+     "start_time": "2023-04-04T18:51:50.639029Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def collect(eq, term):\n",
+    "    return Eq(eq.lhs, eq.rhs.collect(term))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "78cc5307",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.643399Z",
+     "start_time": "2023-04-04T18:51:50.641413Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def simplify_sol_g(sol_g):\n",
+    "    rhs = (\n",
+    "        sol_g\n",
+    "        .rhs\n",
+    "        .rewrite(sin)\n",
+    "        .expand()\n",
+    "        .collect(𝕚)\n",
+    "        .subs(effective_rabi_freq)\n",
+    "        .simplify()\n",
+    "        .subs(find_Ω)\n",
+    "    )\n",
+    "    return Eq(sol_g.lhs, rhs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "3a034ee0",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.692947Z",
+     "start_time": "2023-04-04T18:51:50.644232Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle g{\\left(t \\right)} = \\cos{\\left(\\frac{t Ω_{0}}{2} \\right)}$"
+      ],
+      "text/plain": [
+       "Eq(g(t), cos(t*Ω_0/2))"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sol_g = restore_global_phase(\n",
+    "    simplify_sol_g(\n",
+    "        collect(\n",
+    "            remove_global_phase(\n",
+    "                sols_gen[0]\n",
+    "                .subs(find_Ω)\n",
+    "                .subs(integration_constants)\n",
+    "            ).expand(),\n",
+    "            exp(𝕚 * Ω * t / 2                                                                   )\n",
+    "        )\n",
+    "    )\n",
+    ")\n",
+    "sol_g"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "143d31e9",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.709694Z",
+     "start_time": "2023-04-04T18:51:50.693841Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle e{\\left(t \\right)} = i \\sin{\\left(\\frac{t Ω_{0}}{2} \\right)}$"
+      ],
+      "text/plain": [
+       "Eq(e(t), I*sin(t*Ω_0/2))"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sol_e = restore_global_phase(\n",
+    "    remove_global_phase(\n",
+    "        sols_gen[1].subs(find_Ω).subs(integration_constants)\n",
+    "    ).expand().rewrite(sin).expand()\n",
+    ")\n",
+    "sol_e"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "5480adc7",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.715701Z",
+     "start_time": "2023-04-04T18:51:50.710650Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left|{e{\\left(t \\right)}}\\right|^{2} = \\sin^{2}{\\left(\\frac{t Ω_{0}}{2} \\right)}$"
+      ],
+      "text/plain": [
+       "Eq(Abs(e(t))**2, sin(t*Ω_0/2)**2)"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pop_e = (sol_e.rhs * sol_e.rhs.conjugate())\n",
+    "Eq(Abs(e(t))**2, pop_e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e1e5311",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-02T17:29:49.692024Z",
+     "start_time": "2023-04-02T17:29:49.678226Z"
+    }
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "4b5aa5ea",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.719696Z",
+     "start_time": "2023-04-04T18:51:50.716584Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left[\\begin{matrix}\\cos{\\left(\\frac{t Ω_{0}}{2} \\right)}\\\\i \\sin{\\left(\\frac{t Ω_{0}}{2} \\right)}\\end{matrix}\\right]$"
+      ],
+      "text/plain": [
+       "Matrix([\n",
+       "[  cos(t*Ω_0/2)],\n",
+       "[I*sin(t*Ω_0/2)]])"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Ψ = Matrix([sol_g.rhs, sol_e.rhs])\n",
+    "Ψ"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "3202afa8",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.723124Z",
+     "start_time": "2023-04-04T18:51:50.720701Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ωₗ = symbols(\"omega_l\", positive=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "27026e03",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.727503Z",
+     "start_time": "2023-04-04T18:51:50.724131Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left[\\begin{matrix}1 & 0\\\\0 & e^{- i \\omega_{l} t}\\end{matrix}\\right]$"
+      ],
+      "text/plain": [
+       "Matrix([\n",
+       "[1,                 0],\n",
+       "[0, exp(-I*omega_l*t)]])"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "U = Matrix([[1, 0], [0, exp(-𝕚*ωₗ*t)]])\n",
+    "U"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "c05082d9",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.731481Z",
+     "start_time": "2023-04-04T18:51:50.728539Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left[\\begin{matrix}1 & 0\\\\0 & e^{i \\omega_{l} t}\\end{matrix}\\right]$"
+      ],
+      "text/plain": [
+       "Matrix([\n",
+       "[1,                0],\n",
+       "[0, exp(I*omega_l*t)]])"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "U_dag = U.conjugate().transpose()\n",
+    "U_dag"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "b0c6a2c9",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.735356Z",
+     "start_time": "2023-04-04T18:51:50.732221Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left[\\begin{matrix}\\cos{\\left(\\frac{t Ω_{0}}{2} \\right)}\\\\i e^{i \\omega_{l} t} \\sin{\\left(\\frac{t Ω_{0}}{2} \\right)}\\end{matrix}\\right]$"
+      ],
+      "text/plain": [
+       "Matrix([\n",
+       "[                   cos(t*Ω_0/2)],\n",
+       "[I*exp(I*omega_l*t)*sin(t*Ω_0/2)]])"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Ψ_lab = U_dag @ Ψ\n",
+    "Ψ_lab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "839c9c22",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.738954Z",
+     "start_time": "2023-04-04T18:51:50.736372Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left[\\begin{matrix}0 & 1\\\\1 & 0\\end{matrix}\\right]$"
+      ],
+      "text/plain": [
+       "Matrix([\n",
+       "[0, 1],\n",
+       "[1, 0]])"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "σx = Matrix([[0, 1], [1, 0]])\n",
+    "σx"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "5549c23a",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.742176Z",
+     "start_time": "2023-04-04T18:51:50.739842Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left[\\begin{matrix}0 & - i\\\\i & 0\\end{matrix}\\right]$"
+      ],
+      "text/plain": [
+       "Matrix([\n",
+       "[0, -I],\n",
+       "[I,  0]])"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "σy = Matrix([[0, -𝕚], [𝕚, 0]])\n",
+    "σy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "f3aed051",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.744768Z",
+     "start_time": "2023-04-04T18:51:50.743265Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def inner(a, b):\n",
+    "    return a.dot(b, hermitian=True, conjugate_convention=\"left\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "a01011e4",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.747411Z",
+     "start_time": "2023-04-04T18:51:50.745717Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def expval(O, Ψ):\n",
+    "    return inner(Ψ, O @ Ψ).simplify()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "bd91564e",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.751024Z",
+     "start_time": "2023-04-04T18:51:50.748362Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle 0$"
+      ],
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "expval(σx, Ψ)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "b1b58d4a",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.804249Z",
+     "start_time": "2023-04-04T18:51:50.751780Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle - \\sin{\\left(\\omega_{l} t \\right)} \\sin{\\left(t Ω_{0} \\right)}$"
+      ],
+      "text/plain": [
+       "-sin(omega_l*t)*sin(t*Ω_0)"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "expval(σx, Ψ_lab)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "9a625211",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.818374Z",
+     "start_time": "2023-04-04T18:51:50.805133Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\sin{\\left(t Ω_{0} \\right)}$"
+      ],
+      "text/plain": [
+       "sin(t*Ω_0)"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "expval(σy, Ψ)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "6b4cc70e",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-04-04T18:51:50.853093Z",
+     "start_time": "2023-04-04T18:51:50.819465Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\sin{\\left(t Ω_{0} \\right)} \\cos{\\left(\\omega_{l} t \\right)}$"
+      ],
+      "text/plain": [
+       "sin(t*Ω_0)*cos(omega_l*t)"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "expval(σy, Ψ_lab)"
+   ]
+  }
+ ],
+ "metadata": {
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {
+    "height": "calc(100% - 180px)",
+    "left": "10px",
+    "top": "150px",
+    "width": "346.594px"
+   },
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This is breaking because it adds arguments `tlist`, `i` to the storage-related routines.