### PR TITLE
Show backtraces in interface checks

### DIFF
--- a/src/QuantumPropagators.jl
+++ b/src/QuantumPropagators.jl
@@ -33,6 +33,7 @@ include("exp_propagator.jl")
 module Interfaces
     export check_operator, check_state, check_amplitude, check_control
     export check_generator, check_propagator
+    include(joinpath("interfaces", "utils.jl"))
     include(joinpath("interfaces", "state.jl"))
     include(joinpath("interfaces", "operator.jl"))
     include(joinpath("interfaces", "amplitude.jl"))

--- a/src/interfaces/amplitude.jl
+++ b/src/interfaces/amplitude.jl
@@ -42,7 +42,10 @@ function check_amplitude(
             success = false
         end
     catch exc
-        quiet || @error "$(px)`get_controls(ampl)` must be defined: $exc"
+        quiet || @error(
+            "$(px)`get_controls(ampl)` must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -62,7 +65,10 @@ function check_amplitude(
             end
         end
     catch exc
-        quiet || @error "$(px)all controls in `ampl` must pass `check_control`: $exc"
+        quiet || @error(
+            "$(px)all controls in `ampl` must pass `check_control`.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -75,7 +81,10 @@ function check_amplitude(
             success = false
         end
     catch exc
-        quiet || @error "$(px)`substitute(ampl, replacments)` must be defined: $exc"
+        quiet || @error(
+            "$(px)`substitute(ampl, replacments)` must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -87,7 +96,10 @@ function check_amplitude(
             success = false
         end
     catch exc
-        quiet || @error "$(px)`evaluate(ampl, tlist, n)` must be defined: $exc"
+        quiet || @error(
+            "$(px)`evaluate(ampl, tlist, n)` must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -101,7 +113,10 @@ function check_amplitude(
             success = false
         end
     catch exc
-        quiet || @error "$(px)`evaluate(ampl, tlist, n; vals_dict)` must be defined: $exc"
+        quiet || @error(
+            "$(px)`evaluate(ampl, tlist, n; vals_dict)` must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 

--- a/src/interfaces/control.jl
+++ b/src/interfaces/control.jl
@@ -57,7 +57,10 @@ function check_control(
             success = false
         end
     catch exc
-        quiet || @error "$(px)`discretize(control, tlist)` must be defined: $exc"
+        quiet || @error(
+            "$(px)`discretize(control, tlist)` must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -79,8 +82,10 @@ function check_control(
             success = false
         end
     catch exc
-        quiet ||
-            @error "$(px)`discretize_on_midpoints(control, tlist)` must be defined: $exc"
+        quiet || @error(
+            "$(px)`discretize_on_midpoints(control, tlist)` must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 

--- a/src/interfaces/generator.jl
+++ b/src/interfaces/generator.jl
@@ -55,7 +55,10 @@ function check_generator(
             success = false
         end
     catch exc
-        quiet || @error "$(px)`get_controls(generator)` must be defined: $exc"
+        quiet || @error(
+            "$(px)`get_controls(generator)` must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -77,8 +80,10 @@ function check_generator(
             success = false
         end
     catch exc
-        quiet ||
-            @error "$(px)`evaluate(generator, tlist, n)` must return a valid operator: $exc"
+        quiet || @error(
+            "$(px)`evaluate(generator, tlist, n)` must return a valid operator.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -86,7 +91,10 @@ function check_generator(
         op = evaluate(generator, tlist, 1)
         evaluate!(op, generator, tlist, length(tlist) - 1)
     catch exc
-        quiet || @error "$(px)`evaluate!(op, generator, tlist, n)` must be defined: $exc"
+        quiet || @error(
+            "$(px)`evaluate!(op, generator, tlist, n)` must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -106,7 +114,10 @@ function check_generator(
             end
         end
     catch exc
-        quiet || @error "$(px)all controls in `generator` must pass `check_control`: $exc"
+        quiet || @error(
+            "$(px)all controls in `generator` must pass `check_control`.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -120,7 +131,10 @@ function check_generator(
             success = false
         end
     catch exc
-        quiet || @error "$(px)`substitute(generator, replacements)` must be defined: $exc"
+        quiet || @error(
+            "$(px)`substitute(generator, replacements)` must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -140,8 +154,10 @@ function check_generator(
                 end
             end
         catch exc
-            quiet ||
-                @error "$(px)all elements of `generator.amplitudes` must be valid: $exc"
+            quiet || @error(
+                "$(px)all elements of `generator.amplitudes` must be valid.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
             success = false
         end
     end

--- a/src/interfaces/operator.jl
+++ b/src/interfaces/operator.jl
@@ -70,7 +70,10 @@ function check_operator(
             success = false
         end
     catch exc
-        quiet || @error "$(px)op must not be time-dependent: $exc"
+        quiet || @error(
+            "$(px)op must not be time-dependent.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -82,7 +85,10 @@ function check_operator(
             success = false
         end
     catch exc
-        quiet || @error "$(px)op must not contain any controls: $exc"
+        quiet || @error(
+            "$(px)op must not contain any controls.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -96,7 +102,10 @@ function check_operator(
                 success = false
             end
         catch exc
-            quiet || @error "$(px)`op * state` must be defined: $exc"
+            quiet || @error(
+                "$(px)`op * state` must be defined.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
             success = false
         end
 
@@ -117,8 +126,10 @@ function check_operator(
                 end
             end
         catch exc
-            quiet ||
-                @error "$(px)The 3-argument `mul!` must apply `op` to the given `state`: $exc"
+            quiet || @error(
+                "$(px)The 3-argument `mul!` must apply `op` to the given `state`.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
             success = false
         end
 
@@ -140,8 +151,10 @@ function check_operator(
                 end
             end
         catch exc
-            quiet ||
-                @error "$(px)The 5-argument `mul!` must apply `op` to the given `state`: $exc"
+            quiet || @error(
+                "$(px)The 5-argument `mul!` must apply `op` to the given `state`.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
             success = false
         end
 
@@ -173,7 +186,10 @@ function check_operator(
                 end
             end
         catch exc
-            quiet || @error "$(px)`dot(state, op, state)` must return return a number: $exc"
+            quiet || @error(
+                "$(px)`dot(state, op, state)` must return return a number.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
             success = false
         end
 

--- a/src/interfaces/propagator.jl
+++ b/src/interfaces/propagator.jl
@@ -6,6 +6,7 @@ import ..prop_step!
 import ..set_state!
 import ..set_t!
 
+
 """Check that the given `propagator` implements the required interface.
 
 ```julia
@@ -21,6 +22,7 @@ initialized with [`init_prop`](@ref).
 * `propagator.state` must be a valid state (see [`check_state`](@ref)), with
   support for in-place operations (`for_mutable_state=true`) if
   `propagator.inplace` is true.
+* `propagator.tlist` must be monotonically increasing.
 * `propagator.t` must be the first or last element of `propagator.tlist`,
   depending on `propagator.backward`
 * [`prop_step!(propagator)`](@ref prop_step!) must be defined and return a
@@ -69,7 +71,10 @@ function check_propagator(
         backward = propagator.backward
         inplace = propagator.inplace
     catch exc
-        quiet || @error "$(px)`propagator` does not have the required properties: $exc"
+        quiet || @error(
+            "$(px)`propagator` does not have the required properties.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -88,7 +93,27 @@ function check_propagator(
             success = false
         end
     catch exc
-        quiet || @error "$(px)Cannot verify `propagator.state`: $exc"
+        quiet || @error(
+            "$(px)Cannot verify `propagator.state`.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
+        success = false
+    end
+
+    try
+        _t = tlist[begin]
+        for t in tlist[begin+1:end]
+            if t <= _t
+                quiet || @error "$(px)`propagator.tlist` must be monotonically increasing"
+                success = false
+            end
+            _t = t
+        end
+    catch exc
+        quiet || @error(
+            "$(px)Cannot verify `propagator.tlist`.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -105,7 +130,10 @@ function check_propagator(
             end
         end
     catch exc
-        quiet || @error "$(px)Cannot verify `propagator.t`: $exc"
+        quiet || @error(
+            "$(px)Cannot verify `propagator.t`.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -120,7 +148,7 @@ function check_propagator(
             for_mutable_state=false,
             for_immutable_state=false,
             atol,
-            _message_prefix="On `Ψ₁=propstep!(propagator)`: "
+            _message_prefix="On `Ψ₁=prop_step!(propagator)`: "
         )
         if !valid_state
             quiet ||
@@ -151,7 +179,10 @@ function check_propagator(
             success = false
         end
     catch exc
-        quiet || @error "$(px)`prop_step!(propagator)` must be defined : $exc"
+        quiet || @error(
+            "$(px)`prop_step!(propagator)` must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -167,7 +198,10 @@ function check_propagator(
             success = false
         end
     catch exc
-        quiet || @error "$(px)`set_t!(propagator)` must be defined : $exc"
+        quiet || @error(
+            "$(px)`set_t!(propagator)` must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -187,8 +221,10 @@ function check_propagator(
             end
         end
     catch exc
-        quiet ||
-            @error "$(px)Failed to run `prop_step!(propagator)` at t=$(propagator.t): $exc"
+        quiet || @error(
+            "$(px)Failed to run `prop_step!(propagator)` at t=$(propagator.t).",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -207,7 +243,10 @@ function check_propagator(
             end
         end
     catch exc
-        quiet || @error "$(px)`set_state!(propagator, state)` must be defined : $exc"
+        quiet || @error(
+            "$(px)`set_state!(propagator, state)` must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -222,8 +261,10 @@ function check_propagator(
                 end
             end
         catch exc
-            quiet ||
-                @error "$(px)In a PiecewisePropagator, `propagator.parameters` must be a dict mapping controls to a vector of values, one for each interval on `propagator.tlist`: $exc"
+            quiet || @error(
+                "$(px)In a PiecewisePropagator, `propagator.parameters` must be a dict mapping controls to a vector of values, one for each interval on `propagator.tlist`.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
             success = false
         end
     end
@@ -271,8 +312,10 @@ function check_propagator(
             end
         end
     catch exc
-        quiet ||
-            @error "$(px)`reinit_prop!` must be defined and re-initialize the propagator: $exc"
+        quiet || @error(
+            "$(px)`reinit_prop!` must be defined and re-initialize the propagator.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 

--- a/src/interfaces/state.jl
+++ b/src/interfaces/state.jl
@@ -75,8 +75,10 @@ function check_state(
             success = false
         end
     catch exc
-        quiet ||
-            @error "$(px)the inner product of two states must be a complex number: $exc"
+        quiet || @error(
+            "$(px)the inner product of two states must be a complex number.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -89,8 +91,10 @@ function check_state(
             success = false
         end
     catch exc
-        quiet ||
-            @error "$(px)the norm of a state must be defined via the inner product: $exc"
+        quiet || @error(
+            "$(px)the norm of a state must be defined via the inner product.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
         success = false
     end
 
@@ -109,7 +113,10 @@ function check_state(
                 success = false
             end
         catch exc
-            quiet || @error "$(px)`state + state` and `state - state` must be defined: $exc"
+            quiet || @error(
+                "$(px)`state + state` and `state - state` must be defined.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
             success = false
         end
 
@@ -120,7 +127,10 @@ function check_state(
                 success = false
             end
         catch exc
-            quiet || @error "$(px)copy(state) must be defined: $exc"
+            quiet || @error(
+                "$(px)copy(state) must be defined.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
             success = false
         end
 
@@ -132,7 +142,10 @@ function check_state(
                 success = false
             end
         catch exc
-            quiet || @error "$(px)`c * state` for a scalar `c` must be defined: $exc"
+            quiet || @error(
+                "$(px)`c * state` for a scalar `c` must be defined.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
             success = false
         end
 
@@ -142,7 +155,10 @@ function check_state(
                 success = false
             end
         catch exc
-            quiet || @error "$(px)`0.0 * state` must produce a state with norm 0: $exc"
+            quiet || @error(
+                "$(px)`0.0 * state` must produce a state with norm 0.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
             success = false
         end
 
@@ -155,7 +171,10 @@ function check_state(
         try
             ϕ = similar(state)
         catch exc
-            quiet || @error "$(px)`similar(state)` must be defined: $exc"
+            quiet || @error(
+                "$(px)`similar(state)` must be defined.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
             has_similar = false
             success = false
         end
@@ -192,7 +211,10 @@ function check_state(
                 end
             end
         catch exc
-            quiet || @error("$(px)`copyto!(other, state)` must be defined: $exc")
+            quiet || @error(
+                "$(px)`copyto!(other, state)` must be defined.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
             success = false
         end
 
@@ -210,7 +232,10 @@ function check_state(
                 end
             end
         catch exc
-            quiet || @error("$(px)`lmul!(c, state)` for a scalar `c` must be defined: $exc")
+            quiet || @error(
+                "$(px)`lmul!(c, state)` for a scalar `c` must be defined.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
             success = false
         end
 
@@ -226,8 +251,10 @@ function check_state(
                 end
             end
         catch exc
-            quiet ||
-                @error "$(px)`lmul!(0.0, state)` must produce a state with norm 0: $exc"
+            quiet || @error(
+                "$(px)`lmul!(0.0, state)` must produce a state with norm 0.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
             success = false
         end
 
@@ -245,7 +272,10 @@ function check_state(
                 end
             end
         catch exc
-            quiet || @error "$(px)`axpy!(c, state, other)` must be defined: $exc"
+            quiet || @error(
+                "$(px)`axpy!(c, state, other)` must be defined.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
             success = false
         end
 
@@ -259,7 +289,10 @@ function check_state(
                 success = false
             end
         catch exc
-            quiet || @error "$(px)`norm(state)` must be 1: $exc"
+            quiet || @error(
+                "$(px)`norm(state)` must be 1.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
             success = false
         end
     end

--- a/src/interfaces/utils.jl
+++ b/src/interfaces/utils.jl
@@ -1,0 +1,14 @@
+# https://discourse.julialang.org/t/106649
+function catch_abbreviated_backtrace()
+    bt_caught = catch_backtrace()
+    bt_here = backtrace()
+    N = length(bt_caught)
+    offset = length(bt_here) - N
+    while N > 1
+        if bt_caught[N] ≢ bt_here[N+offset]
+            break
+        end
+        N = N - 1
+    end
+    return bt_caught[1:N]
+end


### PR DESCRIPTION
Any exceptions occurring in the `check_*` routines that test the various interfaces now show a truncated backtrace. This should make it much easier to pinpoint problems.