### PR TITLE
Split up `propagate` into lower-level components

### DIFF
--- a/src/QuantumPropagators.jl
+++ b/src/QuantumPropagators.jl
@@ -31,10 +31,11 @@ include("exp_propagator.jl")
 
 #! format: off
 module Interfaces
-    export check_operator, check_state, check_amplitude, check_control
-    export check_generator, check_propagator
+    export check_operator, check_state, check_tlist, check_amplitude
+    export check_control, check_generator, check_propagator
     include(joinpath("interfaces", "utils.jl"))
     include(joinpath("interfaces", "state.jl"))
+    include(joinpath("interfaces", "tlist.jl"))
     include(joinpath("interfaces", "operator.jl"))
     include(joinpath("interfaces", "amplitude.jl"))
     include(joinpath("interfaces", "control.jl"))

--- a/src/interfaces/propagator.jl
+++ b/src/interfaces/propagator.jl
@@ -80,6 +80,13 @@ function check_propagator(
 
     success || return false  # no point in going on
 
+    valid_tlist =
+        check_tlist(propagator.tlist; quiet, _message_prefix="On `propagator.tlist`: ")
+    if !valid_tlist
+        quiet || @error "$(px)`propagator.tlist` is not a valid time grid"
+        success = false
+    end
+
     try
         valid_state = check_state(
             state;

--- a/src/interfaces/tlist.jl
+++ b/src/interfaces/tlist.jl
@@ -1,0 +1,51 @@
+"""Check that the given `tlist` is valid.
+
+```julia
+@test check_tlist(tlist; quiet=false)
+```
+
+verifies the given time grid. A valid time grid must
+
+* be a `Vector{Float64}`,
+* contain at least two points (beginning and end),
+* be monotonically increasing
+
+The function returns `true` for a valid time grid and `false` for an invalid
+time grid. Unless `quiet=true`, it will log an error to indicated which of the
+conditions failed.
+"""
+function check_tlist(tlist; quiet=false, _message_prefix="")
+
+    px = _message_prefix
+    success = true
+
+    if tlist isa Vector{Float64}
+        if length(tlist) >= 2
+            try
+                _t = tlist[begin]
+                for t in tlist[begin+1:end]
+                    if t <= _t
+                        quiet || @error "$(px)`tlist` must be monotonically increasing"
+                        success = false
+                    end
+                    _t = t
+                end
+            catch exc
+                quiet || @error(
+                    "$(px)Cannot verify `tlist`.",
+                    exception = (exc, catch_abbreviated_backtrace())
+                )
+                success = false
+            end
+        else
+            quiet || @error "$(px)`tlist` must contain at least two points"
+            success = false
+        end
+    else
+        quiet || @error "$(px)`tlist` must be a Vector{Float64}, not $(typeof(tlist))"
+        success = false
+    end
+
+    return success
+
+end

--- a/src/propagator.jl
+++ b/src/propagator.jl
@@ -204,13 +204,13 @@ function init_prop(
     propagator = init_prop(state, generator, tlist, method; backward=backward, kwargs...)
     if piecewise ≡ true
         if !(propagator isa PiecewisePropagator)
-            error("Cannot initalize propagator as piecewise with method=$(repr(method))")
+            error("Cannot initialize propagator as piecewise with method=$(repr(method))")
         end
     end
     if pwc ≡ true
         if !(propagator isa PWCPropagator)
             error(
-                "Cannot initalize propagator as piecewise-constant with method=$(repr(method))"
+                "Cannot initialize propagator as piecewise-constant with method=$(repr(method))"
             )
         end
     end


### PR DESCRIPTION
Allow to call `propagate(propagator)` as a low overhead option to propagate over an entire time grid.

Add `check_tlist` interface routine.

Minor breaking change: renamed `showprogress` to `show_progress`