### PR TITLE
Store `timer_data` in all propagators

### DIFF
--- a/docs/src/benchmarks/profiling.md
+++ b/docs/src/benchmarks/profiling.md
@@ -77,7 +77,7 @@ In any subsequent propagation, we could access the timing data in a `callback` t
 ```@example profiling
 function show_timing_data(propagator, args...)
     if propagator.t == tlist[end]
-        show(propagator.wrk.timing_data, compact=true)
+        show(propagator.timing_data, compact=true)
     end
 end
 
@@ -94,7 +94,7 @@ propagator = init_prop(Ψ₀, H, tlist; method=Cheby)
 for step ∈ 1:(length(tlist)-1)
     prop_step!(propagator)
 end
-show(propagator.wrk.timing_data, compact=true)
+show(propagator.timing_data, compact=true)
 ```
 
 The reported runtimes here are less important than the number of function calls and the runtime percentages. In this case, the timing data shows that the propagation is dominated by the matrix-vector products (applying the Hamiltonian to the state), as it should. The percentage would go to 100% for larger Hilbert spaces.

--- a/ext/QuantumPropagatorsODEExt.jl
+++ b/ext/QuantumPropagatorsODEExt.jl
@@ -168,7 +168,7 @@ init_prop(state, generator, tlist, method::Val{:DifferentialEquations}; kwargs..
 mutable struct ODEContinuousPropagator{IT} <: AbstractPropagator
     const integrator::IT
     const tlist::Vector{Float64}
-    const parameters::AbstractDict
+    parameters::AbstractDict
     const backward::Bool
     const inplace::Bool
     const timing_data::TimerOutput
@@ -181,7 +181,7 @@ mutable struct ODEPWCPropagator{IT} <: PWCPropagator
     # out because it's in a different place in the type hierarchy
     const integrator::IT
     const tlist::Vector{Float64}
-    const parameters::AbstractDict
+    parameters::AbstractDict
     const backward::Bool
     const inplace::Bool
     const timing_data::TimerOutput

--- a/src/cheby.jl
+++ b/src/cheby.jl
@@ -95,13 +95,19 @@ mutable struct ChebyWrk{ST,CFS,FT<:AbstractFloat}
     dt::FT
     limit::FT
     timing_data::TimerOutput
-    function ChebyWrk(Ψ::ST, Δ::FT, E_min::FT, dt::FT; limit::FT=1e-12) where {ST,FT}
+    function ChebyWrk(
+        Ψ::ST,
+        Δ::FT,
+        E_min::FT,
+        dt::FT;
+        limit::FT=1e-12,
+        _timing_data=TimerOutput()
+    ) where {ST,FT}
         v0::ST = similar(Ψ)
         v1::ST = similar(Ψ)
         v2::ST = similar(Ψ)
         coeffs = cheby_coeffs(Δ, dt; limit=limit)
         n_coeffs = length(coeffs)
-        timing_data = TimerOutput()
         new{ST,typeof(coeffs),FT}(
             v0,
             v1,
@@ -112,7 +118,7 @@ mutable struct ChebyWrk{ST,CFS,FT<:AbstractFloat}
             E_min,
             dt,
             limit,
-            timing_data
+            _timing_data
         )
     end
 end

--- a/src/exp_propagator.jl
+++ b/src/exp_propagator.jl
@@ -1,4 +1,5 @@
 using .Controls: get_controls
+using TimerOutputs: reset_timer!, @timeit_debug, TimerOutput
 
 """Propagator for propagation via direct exponentiation
 (`method=QuantumPropagators.ExpProp`)
@@ -6,20 +7,21 @@ using .Controls: get_controls
 This is a [`PWCPropagator`](@ref).
 """
 mutable struct ExpPropagator{GT,OT,ST,WT<:ExpProp.ExpPropWrk} <: PWCPropagator
-    generator::GT
+    const generator::GT
     state::ST
     t::Float64  # time at which current `state` is defined
     n::Int64 # index of next interval to propagate
-    tlist::Vector{Float64}
+    const tlist::Vector{Float64}
     parameters::AbstractDict
     controls
     genop::OT
-    wrk::WT
+    const wrk::WT
     backward::Bool
     inplace::Bool
     convert_state::Type
     convert_operator::Type
     func::Function
+    const timing_data::TimerOutput
 end
 
 
@@ -101,7 +103,8 @@ function init_prop(
     G = _pwc_get_max_genop(generator, controls, tlist)
 
     parameters = _pwc_process_parameters(parameters, controls, tlist)
-    wrk = ExpProp.ExpPropWrk(convert(convert_state, state))
+    timing_data = TimerOutput()
+    wrk = ExpProp.ExpPropWrk(convert(convert_state, state); _timing_data=timing_data)
     n = 1
     t = tlist[1]
     if backward
@@ -127,6 +130,7 @@ function init_prop(
         convert_state,
         convert_operator,
         func,
+        timing_data,
     )
 end
 
@@ -137,26 +141,28 @@ init_prop(state, generator, tlist, method::Val{:expprop}; kwargs...) =
 
 
 function prop_step!(propagator::ExpPropagator)
-    n = propagator.n
-    tlist = getfield(propagator, :tlist)
-    (0 < n < length(tlist)) || return nothing
-    dt = tlist[n+1] - tlist[n]
-    if propagator.backward
-        dt = -dt
-    end
-    Ψ = convert(propagator.convert_state, propagator.state)
-    if propagator.inplace
-        _pwc_set_genop!(propagator, n)
-        H = convert(propagator.convert_operator, propagator.genop)
-        ExpProp.expprop!(Ψ, H, dt, propagator.wrk; func=propagator.func)
-        if Ψ ≢ propagator.state  # `convert` of Ψ may have been a no-op
-            copyto!(propagator.state, convert(typeof(propagator.state), Ψ))
+    @timeit_debug propagator.timing_data "prop_step!" begin
+        n = propagator.n
+        tlist = getfield(propagator, :tlist)
+        (0 < n < length(tlist)) || return nothing
+        dt = tlist[n+1] - tlist[n]
+        if propagator.backward
+            dt = -dt
         end
-    else
-        H = convert(propagator.convert_operator, _pwc_get_genop(propagator, n))
-        Ψ = ExpProp.expprop(Ψ, H, dt, propagator.wrk; func=propagator.func)
-        setfield!(propagator, :state, convert(typeof(propagator.state), Ψ))
+        Ψ = convert(propagator.convert_state, propagator.state)
+        if propagator.inplace
+            _pwc_set_genop!(propagator, n)
+            H = convert(propagator.convert_operator, propagator.genop)
+            ExpProp.expprop!(Ψ, H, dt, propagator.wrk; func=propagator.func)
+            if Ψ ≢ propagator.state  # `convert` of Ψ may have been a no-op
+                copyto!(propagator.state, convert(typeof(propagator.state), Ψ))
+            end
+        else
+            H = convert(propagator.convert_operator, _pwc_get_genop(propagator, n))
+            Ψ = ExpProp.expprop(Ψ, H, dt, propagator.wrk; func=propagator.func)
+            setfield!(propagator, :state, convert(typeof(propagator.state), Ψ))
+        end
+        _pwc_advance_time!(propagator)
+        return propagator.state
     end
-    _pwc_advance_time!(propagator)
-    return propagator.state
 end

--- a/src/newton.jl
+++ b/src/newton.jl
@@ -34,7 +34,7 @@ mutable struct NewtonWrk{T}
     restarts::Int64
     m_max::Int64
     timing_data::TimerOutput
-    function NewtonWrk(v0::T; m_max::Int64=10) where {T}
+    function NewtonWrk(v0::T; m_max::Int64=10, _timing_data=TimerOutput()) where {T}
         if m_max <= 2
             error("Newton propagation requires m_max > 2")
         end
@@ -44,7 +44,6 @@ mutable struct NewtonWrk{T}
                 error("Newton propagation requires state dimension > 2")
             end
         end
-        timing_data = TimerOutput()
         new{T}(
             T[similar(v0) for _ = 1:m_max+1], # arnoldi_vecs
             similar(v0),                       # v
@@ -55,7 +54,7 @@ mutable struct NewtonWrk{T}
             0,                                 # n_leja
             0,                                 # restarts
             m_max,
-            timing_data,
+            _timing_data,
         )
     end
 end

--- a/src/propagator.jl
+++ b/src/propagator.jl
@@ -1,4 +1,5 @@
 using Printf
+using TimerOutputs: reset_timer!
 
 """Abstract base type for all `Propagator` objects.
 
@@ -298,6 +299,13 @@ function reinit_prop!(propagator, state; kwargs...)
         set_t!(propagator, propagator.tlist[end])
     else
         set_t!(propagator, propagator.tlist[begin])
+    end
+    try
+        reset_timer!(propagator.timing_data)
+    catch
+        # All or built-in propagators have `timing_data`, but custom
+        # propagators might not (it's not part of the required interface).
+        # Thus, we fail silently.
     end
 end
 


### PR DESCRIPTION
This makes the piecewise-constant propagators consisten with the OrdinaryDiffEq propagator.