### PR TITLE
Extend `get_parameters`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,15 +17,18 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [weakdeps]
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 
 [extensions]
 QuantumPropagatorsODEExt = "OrdinaryDiffEq"
+QuantumPropagatorsRecursiveArrayToolsExt = "RecursiveArrayTools"
 
 [compat]
-OrdinaryDiffEq = "6.59"
 OffsetArrays = "1"
+OrdinaryDiffEq = "6.59"
 ProgressMeter = "1"
 Random = "1"
+RecursiveArrayTools = "3.12"
 SpecialFunctions = "1, 2"
 StaticArrays = "1"
 TimerOutputs = "0.5.23"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,18 +19,36 @@ if endswith(VERSION, "dev")
 end
 
 links = InterLinks(
+    "Julia" => (
+        "https://docs.julialang.org/en/v1/",
+        "https://docs.julialang.org/en/v1/objects.inv",
+        joinpath(@__DIR__, "src", "inventories", "Julia.toml"),
+    ),
     "TimerOutputs" => (
         "https://github.com/KristofferC/TimerOutputs.jl",
-        joinpath(@__DIR__, "src", "inventories", "TimerOutputs.toml")
+        joinpath(@__DIR__, "src", "inventories", "TimerOutputs.toml"),
     ),
     # We'll use `@extref` for links from docstrings to sections so that the
     # docstrings can also be rendered as part of the QuantumControl
     # documentation.
     "QuantumPropagators" => "https://juliaquantumcontrol.github.io/QuantumPropagators.jl/$DEV_OR_STABLE",
     "QuantumControlBase" => "https://juliaquantumcontrol.github.io/QuantumControlBase.jl/$DEV_OR_STABLE",
+    "ComponentArrays" => (
+        "https://jonniedie.github.io/ComponentArrays.jl/stable/",
+        "https://jonniedie.github.io/ComponentArrays.jl/stable/objects.inv",
+        joinpath(@__DIR__, "src", "inventories", "ComponentArrays.toml")
+    ),
+    "RecursiveArrayTools" => (
+        "https://docs.sciml.ai/RecursiveArrayTools/stable/",
+        "https://docs.sciml.ai/RecursiveArrayTools/stable/objects.inv",
+        joinpath(@__DIR__, "src", "inventories", "RecursiveArrayTools.toml")
+    ),
 )
 
-externals = ExternalFallbacks("Trajectory" => "@extref QuantumControlBase.Trajectory")
+externals = ExternalFallbacks(
+    "Trajectory" => "@extref QuantumControlBase.Trajectory",
+    "ParameterizedFunction" => "@extref `QuantumPropagators.Controls.ParameterizedFunction`"
+)
 
 println("Starting makedocs")
 
@@ -51,6 +69,7 @@ makedocs(;
     # Link checking is disabled in REPL, see `devrepl.jl`.
     linkcheck=(get(ENV, "DOCUMENTER_CHECK_LINKS", "1") != "0"),
     warnonly,
+    doctest=false,  # doctests run as part of test suite
     format=Documenter.HTML(;
         prettyurls=true,
         canonical="https://juliaquantumcontrol.github.io/QuantumPropagators.jl",

--- a/docs/src/benchmarks/profiling.md
+++ b/docs/src/benchmarks/profiling.md
@@ -29,7 +29,7 @@ using BenchmarkTools
 using QuantumPropagators
 using QuantumPropagators: Cheby
 
-@benchmark propagate($Ψ₀, $H, $tlist; method=Cheby) samples=10
+@benchmark propagate($Ψ₀, $H, $tlist; method=Cheby, check=false) samples=10
 ```
 
 ### Newton propagation
@@ -39,7 +39,7 @@ Or, the same propagation with the Newton method:
 ```@example profiling
 using QuantumPropagators: Newton
 
-@benchmark propagate($Ψ₀, $H, $tlist; method=Newton) samples=10
+@benchmark propagate($Ψ₀, $H, $tlist; method=Newton, check=false) samples=10
 ```
 
 The result in this case illustrates the significant advantage of the Chebychev method for systems of moderate to small size and unitary dynamics.

--- a/docs/src/howto.md
+++ b/docs/src/howto.md
@@ -46,3 +46,100 @@ A propagation with [`method=Cheby`](@ref method_cheby) requires that the dynamic
 By default, the Chebychev propagator uses heuristics to estimate  this spectral envelope. If the spectral envelope is known (either analytically of via a separate numerical exploration of the eigenvalues over the full range of possible controls), the minimum and maximum eigenvalues of ``\op{H}(t)`` can be passed as keyword arguments `E_min` and `E_max` to [`propagate`](@ref) or [`init_prop`](@ref). Since the Chebychev method is only defined for Hermitian generators, `E_min` and `E_max` must be real values. Both values must be given.
 
 Manually specifying `E_min` and `E_max` works with the default `specrange_method=:auto` as well as with the explicit `specrange_method=:manual`. When calculating the Chebychev coefficients, the given values may still be enlarged by the default `specrange_buffer` keyword argument in [`init_prop`](@ref). If `E_min` and `E_max` should be used *exactly*, pass `specrange_buffer=0`.
+
+
+## [How to define a parameterized control](@id howto_parameterized)
+
+Parameterized controls are [function-like objects](@extref Julia Function-like-objects) with an associated vector of parameter values that must be accessible via [`QuantumPropagators.Controls.get_parameters`](@ref).
+
+It is recommended to define a parameterized control as a subtype of [`QuantumPropagators.Controls.ParameterizedFunction`](@ref). The packages [`ComponentArrays`](https://github.com/jonniedie/ComponentArrays.jl) and [`UnPack`](https://github.com/mauro3/UnPack.jl) might be useful in the implementing of a suitable type . For example,
+
+
+```jldoctest
+using ComponentArrays
+using UnPack: @unpack
+using QuantumPropagators.Controls: ParameterizedFunction, get_parameters
+
+struct GaussianControl <: ParameterizedFunction
+    parameters::ComponentVector{Float64,Vector{Float64},Tuple{Axis{(A=1, t0=2, sigma=3)}}}
+end
+
+function GaussianControl(; A=1.0, t0=0.0, sigma=1.0)
+    return GaussianControl(ComponentVector(; A, t0, sigma))
+end
+
+function (control::GaussianControl)(t)
+    @unpack A, t0, sigma = control.parameters
+    return A * exp(- (t - t0)^2 / (2 * sigma^2))
+end
+
+# usage
+
+gaussian = GaussianControl(A=2.0, sigma=0.5)
+gaussian.parameters.t0 = 5  # shift center from original 0.0
+
+@show get_parameters(gaussian)
+println("gaussian(4.5) = $(round(gaussian(4.5); digits=3))")
+
+# output
+
+get_parameters(gaussian) = (A = 2.0, t0 = 5.0, sigma = 0.5)
+gaussian(4.5) = 1.213
+```
+
+
+We could put some extra effort into giving direct property access to all
+parameters and to provide unicode-aliases for all parameters:
+
+
+```jldoctest
+using ComponentArrays
+using QuantumPropagators.Controls: ParameterizedFunction, get_parameters
+
+struct GaussianControl <: ParameterizedFunction
+    parameters::ComponentVector{Float64,Vector{Float64},Tuple{Axis{(A=1, t0=2, sigma=3)}}}
+end
+
+function GaussianControl(; A=1.0, t0=0.0, t₀=t0, sigma=1.0, σ=sigma)
+    return GaussianControl(ComponentVector(; A, t0=t₀, sigma=σ))
+end
+
+function Base.propertynames(g::GaussianControl, private::Bool=false)
+    names = (:A, :t0, :t₀, :sigma, :σ)
+    return private ? Tuple(union(names, fieldnames(GaussianControl))) : names
+end
+
+function Base.getproperty(g::GaussianControl, name::Symbol)
+    unicode_aliases = Dict(:σ => :sigma, :t₀ => :t0)
+    getproperty(get_parameters(g), get(unicode_aliases, name, name))
+end
+
+function Base.setproperty!(g::GaussianControl, name::Symbol, value)
+    unicode_aliases = Dict(:σ => :sigma, :t₀ => :t0)
+    setproperty!(
+        get_parameters(g),
+        get(unicode_aliases, name, name),
+        value
+    )
+end
+
+function (control::GaussianControl)(t)
+    A, t₀, σ = get_parameters(control)
+    return A * exp(- (t - t₀)^2 / (2 * σ^2))
+end
+
+# usage
+
+gaussian = GaussianControl(A=2.0, σ=0.5)
+gaussian.t₀ = 5  # shift center from original 0.0
+
+@show get_parameters(gaussian)
+println("gaussian(4.5) = $(round(gaussian(4.5); digits=3))")
+
+# output
+
+get_parameters(gaussian) = (A = 2.0, t0 = 5.0, sigma = 0.5)
+gaussian(4.5) = 1.213
+```
+
+The [`QuantumPropagators.Interfaces.check_parameterized_function`](@ref) can be used to verify the implementation of a [`ParameterizedFunction`](@ref).

--- a/docs/src/inventories/ComponentArrays.toml
+++ b/docs/src/inventories/ComponentArrays.toml
@@ -1,0 +1,193 @@
+# DocInventory version 1
+project = "ComponentArrays.jl"
+version = "0.15.11"
+
+[[jl.method]]
+name = "ComponentArrays.getaxes-Tuple{ComponentArray}"
+uri = "api/#ComponentArrays.getaxes-Tuple%7BComponentArray%7D"
+[[jl.method]]
+name = "ComponentArrays.getdata-Tuple{ComponentArray}"
+uri = "api/#ComponentArrays.getdata-Tuple%7BComponentArray%7D"
+[[jl.method]]
+name = "ComponentArrays.label2index-Tuple{ComponentVector{T, A, Axes} where {T, A, Axes}, Any}"
+uri = "api/#ComponentArrays.label2index-Tuple%7BComponentVector%7BT%2C%20A%2C%20Axes%7D%20where%20%7BT%2C%20A%2C%20Axes%7D%2C%20Any%7D"
+[[jl.method]]
+name = "ComponentArrays.labels-Tuple{ComponentVector{T, A, Axes} where {T, A, Axes}}"
+uri = "api/#ComponentArrays.labels-Tuple%7BComponentVector%7BT%2C%20A%2C%20Axes%7D%20where%20%7BT%2C%20A%2C%20Axes%7D%7D"
+[[jl.method]]
+name = "ComponentArrays.valkeys-Tuple{AbstractAxis}"
+uri = "api/#ComponentArrays.valkeys-Tuple%7BAbstractAxis%7D"
+
+[[jl.type]]
+name = "ComponentArrays.Axis"
+uri = "api/#$"
+[[jl.type]]
+name = "ComponentArrays.ComponentArray"
+uri = "api/#$"
+[[jl.type]]
+name = "ComponentArrays.ComponentMatrix"
+uri = "api/#$"
+[[jl.type]]
+name = "ComponentArrays.ComponentVector"
+uri = "api/#$"
+[[jl.type]]
+name = "ComponentArrays.KeepIndex"
+uri = "api/#$"
+[[jl.type]]
+name = "ComponentArrays.LazyArray"
+uri = "api/#$"
+[[jl.type]]
+name = "ComponentArrays.PartitionedAxis"
+uri = "api/#$"
+[[jl.type]]
+name = "ComponentArrays.ShapedAxis"
+uri = "api/#$"
+[[jl.type]]
+name = "ComponentArrays.ViewAxis"
+uri = "api/#$"
+
+[[std.doc]]
+dispname = "API"
+name = "api"
+uri = "api/"
+[[std.doc]]
+dispname = "Neural ODEs with DiffEqFlux"
+name = "examples/DiffEqFlux"
+uri = "examples/DiffEqFlux/"
+[[std.doc]]
+dispname = "ODE with Jacobian"
+name = "examples/ODE_jac"
+uri = "examples/ODE_jac/"
+[[std.doc]]
+dispname = "Model Reference Adaptive Control"
+name = "examples/adaptive_control"
+uri = "examples/adaptive_control/"
+[[std.doc]]
+dispname = "Home"
+name = "index"
+uri = ""
+[[std.doc]]
+dispname = "Indexing Behavior"
+name = "indexing_behavior"
+uri = "indexing_behavior/"
+[[std.doc]]
+dispname = "Quick Start"
+name = "quickstart"
+uri = "quickstart/"
+[[std.doc]]
+dispname = "Unpacking to StaticArrays"
+name = "static_unpack"
+uri = "static_unpack/"
+
+[[std.label]]
+dispname = "A sliding block with two different friction models"
+name = "A-sliding-block-with-two-different-friction-models"
+uri = "examples/coulomb_control/#$"
+[[std.label]]
+name = "API"
+uri = "api/#$"
+[[std.label]]
+dispname = "Closed-Loop Response"
+name = "Closed-Loop-Response"
+uri = "examples/coulomb_control/#$"
+[[std.label]]
+dispname = "Component Functions"
+name = "Component-Functions"
+uri = "examples/coulomb_control/#$"
+[[std.label]]
+name = "ComponentArrays.jl"
+uri = "#$"
+[[std.label]]
+dispname = "Control of a sliding block"
+name = "Control-of-a-sliding-block"
+uri = "examples/coulomb_control/#$"
+[[std.label]]
+dispname = "Derivative Functions"
+name = "Derivative-Functions"
+uri = "examples/adaptive_control/#$"
+[[std.label]]
+name = "Example"
+uri = "static_unpack/#$"
+[[std.label]]
+dispname = "General use"
+name = "General-use"
+uri = "quickstart/#$"
+[[std.label]]
+dispname = "Helper Functions"
+name = "Helper-Functions"
+uri = "examples/adaptive_control/#$"
+[[std.label]]
+dispname = "Indexing Behavior"
+name = "Indexing-Behavior"
+uri = "indexing_behavior/#$"
+[[std.label]]
+dispname = "Indexing with multiple symbols"
+name = "Indexing-with-multiple-symbols"
+uri = "indexing_behavior/#$"
+[[std.label]]
+dispname = "Insufficient Excitation and Rohr's Example"
+name = "Insufficient-Excitation-and-Rohr's-Example"
+uri = "examples/adaptive_control/#Insufficient-Excitation-and-Rohr%27s-Example"
+[[std.label]]
+dispname = "Laplace Domain Model Specification"
+name = "Laplace-Domain-Model-Specification"
+uri = "examples/adaptive_control/#$"
+[[std.label]]
+dispname = "Model Reference Adaptive Control"
+name = "Model-Reference-Adaptive-Control"
+uri = "examples/adaptive_control/#$"
+[[std.label]]
+name = "Motivation"
+uri = "examples/adaptive_control/#$"
+[[std.label]]
+dispname = "Neural ODEs with DiffEqFlux"
+name = "Neural-ODEs-with-DiffEqFlux"
+uri = "examples/DiffEqFlux/#$"
+[[std.label]]
+dispname = "ODE with Jacobian"
+name = "ODE-with-Jacobian"
+uri = "examples/ODE_jac/#$"
+[[std.label]]
+dispname = "Open-Loop Response"
+name = "Open-Loop-Response"
+uri = "examples/coulomb_control/#$"
+[[std.label]]
+dispname = "PID feedback control"
+name = "PID-feedback-control"
+uri = "examples/coulomb_control/#$"
+[[std.label]]
+dispname = "Problem Setup"
+name = "Problem-Setup"
+uri = "examples/coulomb_control/#$"
+[[std.label]]
+dispname = "Quick Start"
+name = "Quick-Start"
+uri = "quickstart/#$"
+[[std.label]]
+dispname = "Retaining component labels through index operations"
+name = "Retaining-component-labels-through-index-operations"
+uri = "indexing_behavior/#$"
+[[std.label]]
+dispname = "Set Up Simulation"
+name = "Set-Up-Simulation"
+uri = "examples/adaptive_control/#$"
+[[std.label]]
+dispname = "Simulation Inputs"
+name = "Simulation-Inputs"
+uri = "examples/adaptive_control/#$"
+[[std.label]]
+dispname = "Unmodeled Dynamics"
+name = "Unmodeled-Dynamics"
+uri = "examples/adaptive_control/#$"
+[[std.label]]
+dispname = "Unpacking to StaticArrays"
+name = "Unpacking-to-StaticArrays"
+uri = "static_unpack/#$"
+[[std.label]]
+dispname = "Views and slices"
+name = "Views-and-slices"
+uri = "indexing_behavior/#$"
+[[std.label]]
+dispname = "Why not just have static ComponentArrays?"
+name = "Why-not-just-have-static-ComponentArrays?"
+uri = "static_unpack/#Why-not-just-have-static-ComponentArrays%3F"

--- a/docs/src/inventories/Julia.toml
+++ b/docs/src/inventories/Julia.toml
@@ -1,0 +1,10953 @@
+# DocInventory version 1
+project = "The Julia Language"
+version = "1.10.2"
+
+[[jl.constant]]
+name = "Base.ARGS"
+uri = "base/constants/#$"
+[[jl.constant]]
+name = "Base.C_NULL"
+uri = "base/constants/#$"
+[[jl.constant]]
+name = "Base.DEPOT_PATH"
+uri = "base/constants/#$"
+[[jl.constant]]
+name = "Base.DL_LOAD_PATH"
+uri = "stdlib/Libdl/#$"
+[[jl.constant]]
+name = "Base.ENDIAN_BOM"
+uri = "base/io-network/#$"
+[[jl.constant]]
+name = "Base.ENV"
+uri = "base/base/#$"
+[[jl.constant]]
+name = "Base.Inf"
+uri = "base/numbers/#$"
+[[jl.constant]]
+name = "Base.Inf16"
+uri = "base/numbers/#$"
+[[jl.constant]]
+name = "Base.Inf32"
+uri = "base/numbers/#$"
+[[jl.constant]]
+name = "Base.Inf64"
+uri = "base/numbers/#$"
+[[jl.constant]]
+name = "Base.LOAD_PATH"
+uri = "base/constants/#$"
+[[jl.constant]]
+name = "Base.Libc.Libdl.RTLD_NOW"
+uri = "stdlib/Libdl/#$"
+[[jl.constant]]
+name = "Base.Libc.Libdl.dlext"
+uri = "stdlib/Libdl/#$"
+[[jl.constant]]
+name = "Base.MainInclude.ans"
+uri = "base/base/#$"
+[[jl.constant]]
+name = "Base.MainInclude.err"
+uri = "base/base/#$"
+[[jl.constant]]
+name = "Base.MathConstants.catalan"
+uri = "base/numbers/#$"
+[[jl.constant]]
+name = "Base.MathConstants.eulergamma"
+uri = "base/numbers/#$"
+[[jl.constant]]
+name = "Base.MathConstants.golden"
+uri = "base/numbers/#$"
+[[jl.constant]]
+name = "Base.MathConstants.pi"
+uri = "base/numbers/#$"
+[[jl.constant]]
+name = "Base.MathConstants.ℯ"
+uri = "base/numbers/#Base.MathConstants.%E2%84%AF"
+[[jl.constant]]
+name = "Base.NaN"
+uri = "base/numbers/#$"
+[[jl.constant]]
+name = "Base.NaN16"
+uri = "base/numbers/#$"
+[[jl.constant]]
+name = "Base.NaN32"
+uri = "base/numbers/#$"
+[[jl.constant]]
+name = "Base.NaN64"
+uri = "base/numbers/#$"
+[[jl.constant]]
+name = "Base.Order.Forward"
+uri = "base/sort/#$"
+[[jl.constant]]
+name = "Base.Order.Reverse"
+uri = "base/sort/#$"
+[[jl.constant]]
+name = "Base.PROGRAM_FILE"
+uri = "base/constants/#$"
+[[jl.constant]]
+name = "Base.Rounding.RoundDown"
+uri = "base/math/#$"
+[[jl.constant]]
+name = "Base.Rounding.RoundFromZero"
+uri = "base/math/#$"
+[[jl.constant]]
+name = "Base.Rounding.RoundNearest"
+uri = "base/math/#$"
+[[jl.constant]]
+name = "Base.Rounding.RoundNearestTiesAway"
+uri = "base/math/#$"
+[[jl.constant]]
+name = "Base.Rounding.RoundNearestTiesUp"
+uri = "base/math/#$"
+[[jl.constant]]
+name = "Base.Rounding.RoundToZero"
+uri = "base/math/#$"
+[[jl.constant]]
+name = "Base.Rounding.RoundUp"
+uri = "base/math/#$"
+[[jl.constant]]
+name = "Base.Sort.InsertionSort"
+uri = "base/sort/#$"
+[[jl.constant]]
+name = "Base.Sort.MergeSort"
+uri = "base/sort/#$"
+[[jl.constant]]
+name = "Base.Sort.QuickSort"
+uri = "base/sort/#$"
+[[jl.constant]]
+name = "Base.Sys.ARCH"
+uri = "base/constants/#$"
+[[jl.constant]]
+name = "Base.Sys.BINDIR"
+uri = "base/constants/#$"
+[[jl.constant]]
+name = "Base.Sys.CPU_THREADS"
+uri = "base/constants/#$"
+[[jl.constant]]
+name = "Base.Sys.KERNEL"
+uri = "base/constants/#$"
+[[jl.constant]]
+name = "Base.Sys.MACHINE"
+uri = "base/constants/#$"
+[[jl.constant]]
+name = "Base.Sys.STDLIB"
+uri = "base/base/#$"
+[[jl.constant]]
+name = "Base.Sys.WORD_SIZE"
+uri = "base/constants/#$"
+[[jl.constant]]
+name = "Base.VERSION"
+uri = "base/constants/#$"
+[[jl.constant]]
+name = "Base.devnull"
+uri = "base/base/#$"
+[[jl.constant]]
+name = "Base.im"
+uri = "base/numbers/#$"
+[[jl.constant]]
+name = "Base.missing"
+uri = "base/base/#$"
+[[jl.constant]]
+name = "Base.stderr"
+uri = "base/io-network/#$"
+[[jl.constant]]
+name = "Base.stdin"
+uri = "base/io-network/#$"
+[[jl.constant]]
+name = "Base.stdout"
+uri = "base/io-network/#$"
+[[jl.constant]]
+name = "Core.Vararg"
+uri = "base/base/#$"
+[[jl.constant]]
+name = "Core.nothing"
+uri = "base/constants/#$"
+[[jl.constant]]
+name = "Core.undef"
+uri = "base/arrays/#$"
+[[jl.constant]]
+name = "Dates.ISODateFormat"
+uri = "stdlib/Dates/#$"
+[[jl.constant]]
+name = "Dates.ISODateTimeFormat"
+uri = "stdlib/Dates/#$"
+[[jl.constant]]
+name = "Dates.ISOTimeFormat"
+uri = "stdlib/Dates/#$"
+[[jl.constant]]
+name = "Dates.RFC1123Format"
+uri = "stdlib/Dates/#$"
+[[jl.constant]]
+name = "LinearAlgebra.I"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.constant]]
+name = "Logging.Debug"
+uri = "stdlib/Logging/#$"
+[[jl.constant]]
+name = "Logging.Error"
+uri = "stdlib/Logging/#$"
+[[jl.constant]]
+name = "Logging.Info"
+uri = "stdlib/Logging/#$"
+[[jl.constant]]
+name = "Logging.Warn"
+uri = "stdlib/Logging/#$"
+
+[[jl.function]]
+name = "ArgTools.arg_isdir"
+uri = "stdlib/ArgTools/#$"
+[[jl.function]]
+name = "ArgTools.arg_mkdir"
+uri = "stdlib/ArgTools/#$"
+[[jl.function]]
+name = "ArgTools.arg_read"
+uri = "stdlib/ArgTools/#$"
+[[jl.function]]
+name = "ArgTools.arg_readers"
+uri = "stdlib/ArgTools/#$"
+[[jl.function]]
+name = "ArgTools.arg_write"
+uri = "stdlib/ArgTools/#$"
+[[jl.function]]
+name = "ArgTools.arg_writers"
+uri = "stdlib/ArgTools/#$"
+[[jl.function]]
+name = "Artifacts.artifact_hash"
+uri = "stdlib/Artifacts/#$"
+[[jl.function]]
+name = "Artifacts.artifact_meta"
+uri = "stdlib/Artifacts/#$"
+[[jl.function]]
+name = "Artifacts.find_artifacts_toml"
+uri = "stdlib/Artifacts/#$"
+[[jl.function]]
+name = "Base.:!"
+uri = "base/math/#Base.%3A%21"
+[[jl.function]]
+name = "Base.:!="
+uri = "base/math/#Base.%3A%21%3D"
+[[jl.function]]
+name = "Base.:!=="
+uri = "base/math/#Base.%3A%21%3D%3D"
+[[jl.function]]
+name = "Base.:&"
+uri = "base/math/#Base.%3A%26"
+[[jl.function]]
+name = "Base.:+"
+uri = "base/math/#Base.%3A%2B"
+[[jl.function]]
+name = "Base.:/"
+uri = "base/math/#Base.%3A%2F"
+[[jl.function]]
+name = "Base.://"
+uri = "base/math/#Base.%3A%2F%2F"
+[[jl.function]]
+name = "Base.::"
+uri = "base/math/#Base.%3A%3A"
+[[jl.function]]
+name = "Base.:<"
+uri = "base/math/#Base.%3A%3C"
+[[jl.function]]
+name = "Base.:<<"
+uri = "base/math/#Base.%3A%3C%3C"
+[[jl.function]]
+name = "Base.:<="
+uri = "base/math/#Base.%3A%3C%3D"
+[[jl.function]]
+name = "Base.:=="
+uri = "base/math/#Base.%3A%3D%3D"
+[[jl.function]]
+name = "Base.:>"
+uri = "base/math/#Base.%3A%3E"
+[[jl.function]]
+name = "Base.:>:"
+uri = "base/base/#Base.%3A%3E%3A"
+[[jl.function]]
+name = "Base.:>="
+uri = "base/math/#Base.%3A%3E%3D"
+[[jl.function]]
+name = "Base.:>>"
+uri = "base/math/#Base.%3A%3E%3E"
+[[jl.function]]
+name = "Base.:>>>"
+uri = "base/math/#Base.%3A%3E%3E%3E"
+[[jl.function]]
+name = "Base.:|"
+uri = "base/math/#Base.%3A%7C"
+[[jl.function]]
+name = "Base.:|>"
+uri = "base/base/#Base.%3A%7C%3E"
+[[jl.function]]
+name = "Base.:~"
+uri = "base/math/#Base.%3A%7E"
+[[jl.function]]
+name = "Base.:∉"
+uri = "base/collections/#Base.%3A%E2%88%89"
+[[jl.function]]
+name = "Base.:∘"
+uri = "base/base/#Base.%3A%E2%88%98"
+[[jl.function]]
+name = "Base.:⊈"
+uri = "base/collections/#Base.%3A%E2%8A%88"
+[[jl.function]]
+name = "Base.:⊊"
+uri = "base/collections/#Base.%3A%E2%8A%8A"
+[[jl.function]]
+name = "Base.Broadcast.broadcast"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.Broadcast.broadcast!"
+uri = "base/arrays/#Base.Broadcast.broadcast%21"
+[[jl.function]]
+name = "Base.Broadcast.broadcastable"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.Broadcast.combine_axes"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.Broadcast.combine_styles"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.Broadcast.result_style"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.Checked.add_with_overflow"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Checked.checked_abs"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Checked.checked_add"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Checked.checked_cld"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Checked.checked_div"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Checked.checked_fld"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Checked.checked_mod"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Checked.checked_mul"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Checked.checked_neg"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Checked.checked_rem"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Checked.checked_sub"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Checked.mul_with_overflow"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Checked.sub_with_overflow"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Docs.apropos"
+uri = "stdlib/InteractiveUtils/#$"
+[[jl.function]]
+name = "Base.Experimental.register_error_hint"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Experimental.show_error_hints"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Filesystem.abspath"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.basename"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.chmod"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.chown"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.contractuser"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.cp"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.ctime"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.dirname"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.diskstat"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.expanduser"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.filemode"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.gperm"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.hardlink"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.homedir"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.isabspath"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.isblockdev"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.ischardev"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.isdir"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.isdirpath"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.isfifo"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.isfile"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.islink"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.ismount"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.ispath"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.issetgid"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.issetuid"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.issocket"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.issticky"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.joinpath"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.lstat"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.mkdir"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.mkpath"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.mtime"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.mv"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.normpath"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.operm"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.pwd"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.readdir"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.readlink"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.realpath"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.relpath"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.rm"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.samefile"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.splitdir"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.splitdrive"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.splitext"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.splitpath"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.symlink"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.tempdir"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.tempname"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.touch"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.uperm"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.Filesystem.walkdir"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.GC.enable"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.GC.enable_logging"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.GC.gc"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.GC.safepoint"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Iterators.accumulate"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.countfrom"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.cycle"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.drop"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.dropwhile"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.enumerate"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.filter"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.flatmap"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.flatten"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.map"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.only"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.partition"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.peel"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.product"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.repeated"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.rest"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.reverse"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.take"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.takewhile"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Iterators.zip"
+uri = "base/iterators/#$"
+[[jl.function]]
+name = "Base.Libc.FormatMessage"
+uri = "base/libc/#$"
+[[jl.function]]
+name = "Base.Libc.GetLastError"
+uri = "base/libc/#$"
+[[jl.function]]
+name = "Base.Libc.Libdl.dlclose"
+uri = "stdlib/Libdl/#$"
+[[jl.function]]
+name = "Base.Libc.Libdl.dllist"
+uri = "stdlib/Libdl/#$"
+[[jl.function]]
+name = "Base.Libc.Libdl.dlopen"
+uri = "stdlib/Libdl/#$"
+[[jl.function]]
+name = "Base.Libc.Libdl.dlopen_e"
+uri = "stdlib/Libdl/#$"
+[[jl.function]]
+name = "Base.Libc.Libdl.dlpath"
+uri = "stdlib/Libdl/#$"
+[[jl.function]]
+name = "Base.Libc.Libdl.dlsym"
+uri = "stdlib/Libdl/#$"
+[[jl.function]]
+name = "Base.Libc.Libdl.dlsym_e"
+uri = "stdlib/Libdl/#$"
+[[jl.function]]
+name = "Base.Libc.Libdl.find_library"
+uri = "stdlib/Libdl/#$"
+[[jl.function]]
+name = "Base.Libc.calloc"
+uri = "base/libc/#$"
+[[jl.function]]
+name = "Base.Libc.errno"
+uri = "base/libc/#$"
+[[jl.function]]
+name = "Base.Libc.flush_cstdio"
+uri = "base/libc/#$"
+[[jl.function]]
+name = "Base.Libc.free"
+uri = "base/libc/#$"
+[[jl.function]]
+name = "Base.Libc.gethostname"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Libc.getpid"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Libc.malloc"
+uri = "base/libc/#$"
+[[jl.function]]
+name = "Base.Libc.realloc"
+uri = "base/libc/#$"
+[[jl.function]]
+name = "Base.Libc.strerror"
+uri = "base/libc/#$"
+[[jl.function]]
+name = "Base.Libc.strftime"
+uri = "base/libc/#$"
+[[jl.function]]
+name = "Base.Libc.strptime"
+uri = "base/libc/#$"
+[[jl.function]]
+name = "Base.Libc.systemsleep"
+uri = "base/libc/#$"
+[[jl.function]]
+name = "Base.MPFR.setprecision"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.MainInclude.eval"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.MainInclude.include"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Math.acosd"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.acotd"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.acscd"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.asecd"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.asind"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.atand"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.cbrt"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.clamp"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.clamp!"
+uri = "base/math/#Base.Math.clamp%21"
+[[jl.function]]
+name = "Base.Math.cosc"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.cosd"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.cospi"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.cotd"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.cscd"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.deg2rad"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.evalpoly"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.exponent"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.Math.frexp"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.hypot"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.ldexp"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.mod2pi"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.modf"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.rad2deg"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.rem2pi"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.secd"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.significand"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.Math.sinc"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.sincosd"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.sincospi"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.sind"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.sinpi"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Math.tand"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.Meta.lower"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Meta.quot"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Meta.show_sexpr"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Multimedia.display"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.Multimedia.displayable"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.Multimedia.istextmime"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.Multimedia.popdisplay"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.Multimedia.pushdisplay"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.Multimedia.redisplay"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.Multimedia.showable"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.Order.lt"
+uri = "base/sort/#$"
+[[jl.function]]
+name = "Base.Order.ord"
+uri = "base/sort/#$"
+[[jl.function]]
+name = "Base.PipeBuffer"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.Rounding.get_zero_subnormals"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.Rounding.rounding"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.Rounding.set_zero_subnormals"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.Sort.insorted"
+uri = "base/sort/#$"
+[[jl.function]]
+name = "Base.Sort.partialsort"
+uri = "base/sort/#$"
+[[jl.function]]
+name = "Base.Sort.partialsort!"
+uri = "base/sort/#Base.Sort.partialsort%21"
+[[jl.function]]
+name = "Base.Sort.partialsortperm"
+uri = "base/sort/#$"
+[[jl.function]]
+name = "Base.Sort.partialsortperm!"
+uri = "base/sort/#Base.Sort.partialsortperm%21"
+[[jl.function]]
+name = "Base.Sort.searchsorted"
+uri = "base/sort/#$"
+[[jl.function]]
+name = "Base.Sort.searchsortedfirst"
+uri = "base/sort/#$"
+[[jl.function]]
+name = "Base.Sort.searchsortedlast"
+uri = "base/sort/#$"
+[[jl.function]]
+name = "Base.Sort.sortperm!"
+uri = "base/sort/#Base.Sort.sortperm%21"
+[[jl.function]]
+name = "Base.StackTraces.lookup"
+uri = "base/stacktraces/#$"
+[[jl.function]]
+name = "Base.StackTraces.remove_frames!"
+uri = "base/stacktraces/#Base.StackTraces.remove_frames%21"
+[[jl.function]]
+name = "Base.StackTraces.stacktrace"
+uri = "base/stacktraces/#$"
+[[jl.function]]
+name = "Base.Sys.free_memory"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.free_physical_memory"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.get_process_title"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.isapple"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.isbsd"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.isdragonfly"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.isexecutable"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.isfreebsd"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.isjsvm"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.islinux"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.isnetbsd"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.isopenbsd"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.isunix"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.iswindows"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.loadavg"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.set_process_title"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.total_memory"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.total_physical_memory"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.uptime"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Sys.windows_version"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.Threads.atomic_add!"
+uri = "base/multi-threading/#Base.Threads.atomic_add%21"
+[[jl.function]]
+name = "Base.Threads.atomic_and!"
+uri = "base/multi-threading/#Base.Threads.atomic_and%21"
+[[jl.function]]
+name = "Base.Threads.atomic_cas!"
+uri = "base/multi-threading/#Base.Threads.atomic_cas%21"
+[[jl.function]]
+name = "Base.Threads.atomic_fence"
+uri = "base/multi-threading/#$"
+[[jl.function]]
+name = "Base.Threads.atomic_max!"
+uri = "base/multi-threading/#Base.Threads.atomic_max%21"
+[[jl.function]]
+name = "Base.Threads.atomic_min!"
+uri = "base/multi-threading/#Base.Threads.atomic_min%21"
+[[jl.function]]
+name = "Base.Threads.atomic_nand!"
+uri = "base/multi-threading/#Base.Threads.atomic_nand%21"
+[[jl.function]]
+name = "Base.Threads.atomic_or!"
+uri = "base/multi-threading/#Base.Threads.atomic_or%21"
+[[jl.function]]
+name = "Base.Threads.atomic_sub!"
+uri = "base/multi-threading/#Base.Threads.atomic_sub%21"
+[[jl.function]]
+name = "Base.Threads.atomic_xchg!"
+uri = "base/multi-threading/#Base.Threads.atomic_xchg%21"
+[[jl.function]]
+name = "Base.Threads.atomic_xor!"
+uri = "base/multi-threading/#Base.Threads.atomic_xor%21"
+[[jl.function]]
+name = "Base.Threads.foreach"
+uri = "base/multi-threading/#$"
+[[jl.function]]
+name = "Base.Threads.maxthreadid"
+uri = "base/multi-threading/#$"
+[[jl.function]]
+name = "Base.Threads.ngcthreads"
+uri = "base/multi-threading/#$"
+[[jl.function]]
+name = "Base.Threads.nthreadpools"
+uri = "base/multi-threading/#$"
+[[jl.function]]
+name = "Base.Threads.nthreads"
+uri = "base/multi-threading/#$"
+[[jl.function]]
+name = "Base.Threads.threadid"
+uri = "base/multi-threading/#$"
+[[jl.function]]
+name = "Base.Threads.threadpool"
+uri = "base/multi-threading/#$"
+[[jl.function]]
+name = "Base.Threads.threadpoolsize"
+uri = "base/multi-threading/#$"
+[[jl.function]]
+name = "Base.Unicode.iscntrl"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.Unicode.isdigit"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.Unicode.isletter"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.Unicode.islowercase"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.Unicode.isnumeric"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.Unicode.isprint"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.Unicode.ispunct"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.Unicode.isspace"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.Unicode.isuppercase"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.Unicode.isxdigit"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.Unicode.lowercase"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.Unicode.lowercasefirst"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.Unicode.textwidth"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.Unicode.titlecase"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.Unicode.uppercase"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.Unicode.uppercasefirst"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.__precompile__"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.abs"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.abs2"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.accumulate"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.accumulate!"
+uri = "base/arrays/#Base.accumulate%21"
+[[jl.function]]
+name = "Base.acquire"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.active_project"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.add_sum"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.addenv"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.adjoint"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "Base.all!"
+uri = "base/collections/#Base.all%21"
+[[jl.function]]
+name = "Base.allequal"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.allunique"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.angle"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.any!"
+uri = "base/collections/#Base.any%21"
+[[jl.function]]
+name = "Base.append!"
+uri = "base/collections/#Base.append%21"
+[[jl.function]]
+name = "Base.argmax"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.argmin"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.ascii"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.asyncmap"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.asyncmap!"
+uri = "base/parallel/#Base.asyncmap%21"
+[[jl.function]]
+name = "Base.atexit"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.atreplinit"
+uri = "stdlib/REPL/#$"
+[[jl.function]]
+name = "Base.backtrace"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.big"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.bind"
+uri = "stdlib/Sockets/#$"
+[[jl.function]]
+name = "Base.binomial"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.bitrotate"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.bitstring"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.bswap"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.bytes2hex"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.bytesavailable"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.cat"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.catch_backtrace"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.cconvert"
+uri = "base/c/#$"
+[[jl.function]]
+name = "Base.ceil"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.checkbounds"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.checked_length"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.checkindex"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.chomp"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.chop"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.chopprefix"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.chopsuffix"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.circcopy!"
+uri = "base/arrays/#Base.circcopy%21"
+[[jl.function]]
+name = "Base.circshift"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.circshift!"
+uri = "base/arrays/#Base.circshift%21"
+[[jl.function]]
+name = "Base.cis"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.cispi"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.cld"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.close"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.closewrite"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.cmp"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.coalesce"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.code_lowered"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.code_typed"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.codepoint"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.codeunit"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.codeunits"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.compilecache"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.conj"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.conj!"
+uri = "base/arrays/#Base.conj%21"
+[[jl.function]]
+name = "Base.contains"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.convert"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.copy"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.copy!"
+uri = "base/arrays/#Base.copy%21"
+[[jl.function]]
+name = "Base.copysign"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.copyto!"
+uri = "base/c/#Base.copyto%21"
+[[jl.function]]
+name = "Base.count"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.count_ones"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.count_zeros"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.countlines"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.cumprod"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.cumprod!"
+uri = "base/arrays/#Base.cumprod%21"
+[[jl.function]]
+name = "Base.cumsum"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.cumsum!"
+uri = "base/arrays/#Base.cumsum%21"
+[[jl.function]]
+name = "Base.current_exceptions"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.current_task"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.datatype_alignment"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.datatype_haspadding"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.datatype_pointerfree"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.deepcopy"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.delete!"
+uri = "base/collections/#Base.delete%21"
+[[jl.function]]
+name = "Base.deleteat!"
+uri = "base/collections/#Base.deleteat%21"
+[[jl.function]]
+name = "Base.denominator"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.detach"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.diff"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.digits"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.digits!"
+uri = "base/numbers/#Base.digits%21"
+[[jl.function]]
+name = "Base.disable_sigint"
+uri = "base/c/#$"
+[[jl.function]]
+name = "Base.displaysize"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.div"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.divrem"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.download"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.dropdims"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.dump"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.eachcol"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.eachindex"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.eachline"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.eachmatch"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.eachrow"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.eachslice"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.eachsplit"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.elsize"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.eltype"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.empty"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.empty!"
+uri = "base/collections/#Base.empty%21"
+[[jl.function]]
+name = "Base.endswith"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.eof"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.error"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.errormonitor"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.esc"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.escape_string"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.evalfile"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.exit"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.exit_on_sigint"
+uri = "base/c/#$"
+[[jl.function]]
+name = "Base.exp10"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.exp2"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.expm1"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.extrema"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.extrema!"
+uri = "base/collections/#Base.extrema%21"
+[[jl.function]]
+name = "Base.factorial"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.falses"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.fd"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.fdio"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.fieldcount"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.fieldname"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.fieldnames"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.fieldoffset"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.fieldtypes"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.filesize"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.fill"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.fill!"
+uri = "base/arrays/#Base.fill%21"
+[[jl.function]]
+name = "Base.filter"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.filter!"
+uri = "base/collections/#Base.filter%21"
+[[jl.function]]
+name = "Base.finalize"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.finalizer"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.findmax"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.findmax!"
+uri = "base/collections/#Base.findmax%21"
+[[jl.function]]
+name = "Base.findmin"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.findmin!"
+uri = "base/collections/#Base.findmin%21"
+[[jl.function]]
+name = "Base.first"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.firstindex"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.fld"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.fld1"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.fldmod"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.fldmod1"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.flipsign"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.floatmax"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.floatmin"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.floor"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.flush"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.fma"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.foreach"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.front"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.fullname"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.gcd"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.gcdx"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.gensym"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.get"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.get!"
+uri = "base/collections/#Base.get%21"
+[[jl.function]]
+name = "Base.get_extension"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.getindex"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.getkey"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.getproperty"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.hasfield"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.hash"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.haskey"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.hasmethod"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.hasproperty"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.hcat"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.hex2bytes"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.hex2bytes!"
+uri = "base/numbers/#Base.hex2bytes%21"
+[[jl.function]]
+name = "Base.htol"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.hton"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.hvcat"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.hvncat"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.identify_package"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.identity"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.ifelse"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.ignorestatus"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.imag"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.in"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.include"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.include_dependency"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.include_string"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.indexin"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.insert!"
+uri = "base/collections/#Base.insert%21"
+[[jl.function]]
+name = "Base.instances"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.intersect"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.intersect!"
+uri = "base/collections/#Base.intersect%21"
+[[jl.function]]
+name = "Base.invmod"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.invokelatest"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.invperm"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.invpermute!"
+uri = "base/arrays/#Base.invpermute%21"
+[[jl.function]]
+name = "Base.isabstracttype"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isambiguous"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isapprox"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.isascii"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.isassigned"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.isbinaryoperator"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isbits"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isbitstype"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isconcretetype"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isconst"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isdisjoint"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.isdispatchtuple"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isempty"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.isequal"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.iseven"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.isexpr"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isfieldatomic"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isfinite"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.isidentifier"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isimmutable"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isinf"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.isinteger"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.isinteractive"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isless"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.islocked"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.ismarked"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.ismissing"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.ismutable"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.ismutabletype"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isnan"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.isnothing"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isodd"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.isone"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.isopen"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.isoperator"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isperm"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.ispow2"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.isprecompiled"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isprimitivetype"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isqrt"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.isreadable"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.isreadonly"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.isreal"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.issetequal"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.issingletontype"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.issorted"
+uri = "base/sort/#$"
+[[jl.function]]
+name = "Base.isstructtype"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.issubnormal"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.issubset"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.istaskdone"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.istaskfailed"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.istaskstarted"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.isunaryoperator"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.isunordered"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.iswritable"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.iszero"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.iterate"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.jit_total_bytes"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.join"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.keepat!"
+uri = "base/collections/#Base.keepat%21"
+[[jl.function]]
+name = "Base.keys"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.keytype"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.kron"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "Base.kron!"
+uri = "stdlib/LinearAlgebra/#Base.kron%21"
+[[jl.function]]
+name = "Base.last"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.lastindex"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.lcm"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.leading_ones"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.leading_zeros"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.length"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.locate_package"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.lock"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.log10"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.log1p"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.log2"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.lpad"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.lstrip"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.ltoh"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.macroexpand"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.map"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.map!"
+uri = "base/collections/#Base.map%21"
+[[jl.function]]
+name = "Base.mapslices"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.mark"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.match"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.max"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.maximum"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.maximum!"
+uri = "base/collections/#Base.maximum%21"
+[[jl.function]]
+name = "Base.maxintfloat"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.memcmp"
+uri = "base/libc/#$"
+[[jl.function]]
+name = "Base.memcpy"
+uri = "base/libc/#$"
+[[jl.function]]
+name = "Base.memmove"
+uri = "base/libc/#$"
+[[jl.function]]
+name = "Base.memset"
+uri = "base/libc/#$"
+[[jl.function]]
+name = "Base.merge"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.merge!"
+uri = "base/collections/#Base.merge%21"
+[[jl.function]]
+name = "Base.mergewith"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.mergewith!"
+uri = "base/collections/#Base.mergewith%21"
+[[jl.function]]
+name = "Base.methods"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.min"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.minimum"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.minimum!"
+uri = "base/collections/#Base.minimum%21"
+[[jl.function]]
+name = "Base.minmax"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.mod"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.mod1"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.modifyproperty!"
+uri = "base/base/#Base.modifyproperty%21"
+[[jl.function]]
+name = "Base.moduleroot"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.muladd"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.names"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.nand"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.ndigits"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.ndims"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.nextfloat"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.nextind"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.nextpow"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.nextprod"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.nonmissingtype"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.nor"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.notify"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.notnothing"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.ntoh"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.ntuple"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.numerator"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.objectid"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.occursin"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.oftype"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.one"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.ones"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.oneunit"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.open"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.pairs"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.parent"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.parentindices"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.parentmodule"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.parse"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.peek"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.permutedims"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.permutedims!"
+uri = "base/arrays/#Base.permutedims%21"
+[[jl.function]]
+name = "Base.pointer"
+uri = "base/c/#$"
+[[jl.function]]
+name = "Base.pointer_from_objref"
+uri = "base/c/#$"
+[[jl.function]]
+name = "Base.pop!"
+uri = "base/collections/#Base.pop%21"
+[[jl.function]]
+name = "Base.popat!"
+uri = "base/collections/#Base.popat%21"
+[[jl.function]]
+name = "Base.popfirst!"
+uri = "base/collections/#Base.popfirst%21"
+[[jl.function]]
+name = "Base.position"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.powermod"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.precision"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.precompile"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.prepend!"
+uri = "base/collections/#Base.prepend%21"
+[[jl.function]]
+name = "Base.prevfloat"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.prevind"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.prevpow"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.print"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.println"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.printstyled"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.process_exited"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.process_running"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.prod"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.prod!"
+uri = "base/collections/#Base.prod%21"
+[[jl.function]]
+name = "Base.promote"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.promote_rule"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.promote_shape"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.promote_type"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.promote_typejoin"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.propertynames"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.push!"
+uri = "base/collections/#Base.push%21"
+[[jl.function]]
+name = "Base.pushfirst!"
+uri = "base/collections/#Base.pushfirst%21"
+[[jl.function]]
+name = "Base.rand"
+uri = "stdlib/Random/#$"
+[[jl.function]]
+name = "Base.randn"
+uri = "stdlib/Random/#$"
+[[jl.function]]
+name = "Base.range"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.rationalize"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.read"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.read!"
+uri = "base/io-network/#Base.read%21"
+[[jl.function]]
+name = "Base.readavailable"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.readbytes!"
+uri = "base/io-network/#Base.readbytes%21"
+[[jl.function]]
+name = "Base.readchomp"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.readeach"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.readline"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.readlines"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.readuntil"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.real"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.redirect_stderr"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.redirect_stdin"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.redirect_stdio"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.redirect_stdout"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.reenable_sigint"
+uri = "base/c/#$"
+[[jl.function]]
+name = "Base.reim"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.reinterpret"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.release"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.rem"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.repeat"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.replace!"
+uri = "base/collections/#Base.replace%21"
+[[jl.function]]
+name = "Base.replaceproperty!"
+uri = "base/base/#Base.replaceproperty%21"
+[[jl.function]]
+name = "Base.require"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.reshape"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.resize!"
+uri = "base/collections/#Base.resize%21"
+[[jl.function]]
+name = "Base.rest"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.rethrow"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.retry"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.reverse!"
+uri = "base/arrays/#Base.reverse%21"
+[[jl.function]]
+name = "Base.reverseind"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.rot180"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.rotl90"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.rotr90"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.rpad"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.rsplit"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.rstrip"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.run"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.runtests"
+uri = "stdlib/Test/#$"
+[[jl.function]]
+name = "Base.schedule"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.seek"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.seekend"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.seekstart"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.selectdim"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.set_active_project"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.setcpuaffinity"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.setdiff"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.setdiff!"
+uri = "base/collections/#Base.setdiff%21"
+[[jl.function]]
+name = "Base.setenv"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.setindex!"
+uri = "base/collections/#Base.setindex%21"
+[[jl.function]]
+name = "Base.setproperty!"
+uri = "base/base/#Base.setproperty%21"
+[[jl.function]]
+name = "Base.showerror"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.sign"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.signbit"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.signed"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.similar"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.size"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.sizehint!"
+uri = "base/collections/#Base.sizehint%21"
+[[jl.function]]
+name = "Base.skip"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.skipchars"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.skipmissing"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.sleep"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.something"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.sort"
+uri = "base/sort/#$"
+[[jl.function]]
+name = "Base.sort!"
+uri = "base/sort/#Base.sort%21"
+[[jl.function]]
+name = "Base.sortperm"
+uri = "base/sort/#$"
+[[jl.function]]
+name = "Base.sortslices"
+uri = "base/sort/#$"
+[[jl.function]]
+name = "Base.splat"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.splice!"
+uri = "base/collections/#Base.splice%21"
+[[jl.function]]
+name = "Base.split"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.split_rest"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.sprint"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.stack"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.startswith"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.stat"
+uri = "base/file/#$"
+[[jl.function]]
+name = "Base.step"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.stride"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.strides"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.string"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.strip"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.success"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.sum"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.sum!"
+uri = "base/collections/#Base.sum%21"
+[[jl.function]]
+name = "Base.summary"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.summarysize"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.supertype"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.swapproperty!"
+uri = "base/base/#Base.swapproperty%21"
+[[jl.function]]
+name = "Base.symdiff"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.symdiff!"
+uri = "base/collections/#Base.symdiff%21"
+[[jl.function]]
+name = "Base.systemerror"
+uri = "base/c/#$"
+[[jl.function]]
+name = "Base.tail"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.thisind"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.time_ns"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.timedwait"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.to_indices"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.trailing_ones"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.trailing_zeros"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.transcode"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.transpose"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "Base.trues"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.trunc"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.truncate"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.trylock"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.tryparse"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.typeintersect"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.typejoin"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.typemax"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.typemin"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.unescape_string"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.union"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.union!"
+uri = "base/collections/#Base.union%21"
+[[jl.function]]
+name = "Base.unique"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.unique!"
+uri = "base/collections/#Base.unique%21"
+[[jl.function]]
+name = "Base.unlock"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.unmark"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.unsafe_convert"
+uri = "base/c/#$"
+[[jl.function]]
+name = "Base.unsafe_load"
+uri = "base/c/#$"
+[[jl.function]]
+name = "Base.unsafe_modify!"
+uri = "base/c/#Base.unsafe_modify%21"
+[[jl.function]]
+name = "Base.unsafe_pointer_to_objref"
+uri = "base/c/#$"
+[[jl.function]]
+name = "Base.unsafe_read"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.unsafe_replace!"
+uri = "base/c/#Base.unsafe_replace%21"
+[[jl.function]]
+name = "Base.unsafe_store!"
+uri = "base/c/#Base.unsafe_store%21"
+[[jl.function]]
+name = "Base.unsafe_string"
+uri = "base/strings/#$"
+[[jl.function]]
+name = "Base.unsafe_swap!"
+uri = "base/c/#Base.unsafe_swap%21"
+[[jl.function]]
+name = "Base.unsafe_trunc"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.unsafe_write"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.unsigned"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.valtype"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.values"
+uri = "base/collections/#$"
+[[jl.function]]
+name = "Base.vcat"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.vec"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.vect"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.view"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base.wait"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.widemul"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.widen"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.windowserror"
+uri = "base/c/#$"
+[[jl.function]]
+name = "Base.withenv"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Base.write"
+uri = "base/io-network/#$"
+[[jl.function]]
+name = "Base.xor"
+uri = "base/math/#$"
+[[jl.function]]
+name = "Base.yield"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.yieldto"
+uri = "base/parallel/#$"
+[[jl.function]]
+name = "Base.zero"
+uri = "base/numbers/#$"
+[[jl.function]]
+name = "Base.zeros"
+uri = "base/arrays/#$"
+[[jl.function]]
+name = "Base64.base64decode"
+uri = "stdlib/Base64/#$"
+[[jl.function]]
+name = "Base64.base64encode"
+uri = "stdlib/Base64/#$"
+[[jl.function]]
+name = "Base64.stringmime"
+uri = "stdlib/Base64/#$"
+[[jl.function]]
+name = "CRC32c.crc32c"
+uri = "stdlib/CRC32c/#$"
+[[jl.function]]
+name = "Core.:<:"
+uri = "base/base/#Core.%3A%3C%3A"
+[[jl.function]]
+name = "Core.:==="
+uri = "base/base/#Core.%3A%3D%3D%3D"
+[[jl.function]]
+name = "Core.Compiler.EscapeAnalysis.analyze_escapes"
+uri = "devdocs/EscapeAnalysis/#$"
+[[jl.function]]
+name = "Core.Compiler.EscapeAnalysis.is_ipo_profitable"
+uri = "devdocs/EscapeAnalysis/#$"
+[[jl.function]]
+name = "Core.Intrinsics.cglobal"
+uri = "base/c/#$"
+[[jl.function]]
+name = "Core.Intrinsics.llvmcall"
+uri = "base/c/#$"
+[[jl.function]]
+name = "Core.applicable"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Core.eval"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Core.fieldtype"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Core.getfield"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Core.getglobal"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Core.invoke"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Core.isa"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Core.isdefined"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Core.modifyfield!"
+uri = "base/base/#Core.modifyfield%21"
+[[jl.function]]
+name = "Core.nfields"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Core.replacefield!"
+uri = "base/base/#Core.replacefield%21"
+[[jl.function]]
+name = "Core.setfield!"
+uri = "base/base/#Core.setfield%21"
+[[jl.function]]
+name = "Core.setglobal!"
+uri = "base/base/#Core.setglobal%21"
+[[jl.function]]
+name = "Core.swapfield!"
+uri = "base/base/#Core.swapfield%21"
+[[jl.function]]
+name = "Core.throw"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Core.tuple"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Core.typeassert"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Core.typeof"
+uri = "base/base/#$"
+[[jl.function]]
+name = "Dates.canonicalize"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.date2epochdays"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.datetime2epochms"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.datetime2julian"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.datetime2rata"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.datetime2unix"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.day"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.dayabbr"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.dayname"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.dayofmonth"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.dayofquarter"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.dayofweek"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.dayofweekofmonth"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.dayofyear"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.daysinmonth"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.daysinyear"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.daysofweekinmonth"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.default"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.epochdays2date"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.epochms2datetime"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.firstdayofmonth"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.firstdayofquarter"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.firstdayofweek"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.firstdayofyear"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.floorceil"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.hour"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.isleapyear"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.julian2datetime"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.lastdayofmonth"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.lastdayofquarter"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.lastdayofweek"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.lastdayofyear"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.microsecond"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.millisecond"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.minute"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.month"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.monthabbr"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.monthday"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.monthname"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.nanosecond"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.periods"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.quarterofyear"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.rata2datetime"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.second"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.today"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.tofirst"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.tolast"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.unix2datetime"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.value"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.week"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.year"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.yearmonth"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "Dates.yearmonthday"
+uri = "stdlib/Dates/#$"
+[[jl.function]]
+name = "DelimitedFiles.writedlm"
+uri = "stdlib/DelimitedFiles/#$"
+[[jl.function]]
+name = "Distributed.addprocs"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Distributed.channel_from_id"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Distributed.default_addprocs_params"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Distributed.default_worker_pool"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Distributed.init_worker"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Distributed.interrupt"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Distributed.launch"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Distributed.manage"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Distributed.myid"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Distributed.nprocs"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Distributed.nworkers"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Distributed.pmap"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Distributed.process_messages"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Distributed.remote"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Distributed.remoteref_id"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Distributed.rmprocs"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Distributed.start_worker"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Distributed.worker_id_from_socket"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Distributed.workers"
+uri = "stdlib/Distributed/#$"
+[[jl.function]]
+name = "Downloads.download"
+uri = "stdlib/Downloads/#$"
+[[jl.function]]
+name = "Downloads.request"
+uri = "stdlib/Downloads/#$"
+[[jl.function]]
+name = "FileWatching.Pidfile.isvalidpid"
+uri = "stdlib/FileWatching/#$"
+[[jl.function]]
+name = "FileWatching.Pidfile.mkpidlock"
+uri = "stdlib/FileWatching/#$"
+[[jl.function]]
+name = "FileWatching.Pidfile.open_exclusive"
+uri = "stdlib/FileWatching/#$"
+[[jl.function]]
+name = "FileWatching.Pidfile.parse_pidfile"
+uri = "stdlib/FileWatching/#$"
+[[jl.function]]
+name = "FileWatching.Pidfile.stale_pidfile"
+uri = "stdlib/FileWatching/#$"
+[[jl.function]]
+name = "FileWatching.Pidfile.trymkpidlock"
+uri = "stdlib/FileWatching/#$"
+[[jl.function]]
+name = "FileWatching.Pidfile.tryopen_exclusive"
+uri = "stdlib/FileWatching/#$"
+[[jl.function]]
+name = "FileWatching.Pidfile.write_pidfile"
+uri = "stdlib/FileWatching/#$"
+[[jl.function]]
+name = "FileWatching.poll_fd"
+uri = "stdlib/FileWatching/#$"
+[[jl.function]]
+name = "FileWatching.poll_file"
+uri = "stdlib/FileWatching/#$"
+[[jl.function]]
+name = "FileWatching.unwatch_folder"
+uri = "stdlib/FileWatching/#$"
+[[jl.function]]
+name = "FileWatching.watch_file"
+uri = "stdlib/FileWatching/#$"
+[[jl.function]]
+name = "FileWatching.watch_folder"
+uri = "stdlib/FileWatching/#$"
+[[jl.function]]
+name = "Future.copy!"
+uri = "stdlib/Future/#Future.copy%21"
+[[jl.function]]
+name = "Future.randjump"
+uri = "stdlib/Future/#$"
+[[jl.function]]
+name = "InteractiveUtils.clipboard"
+uri = "stdlib/InteractiveUtils/#$"
+[[jl.function]]
+name = "InteractiveUtils.code_llvm"
+uri = "stdlib/InteractiveUtils/#$"
+[[jl.function]]
+name = "InteractiveUtils.code_native"
+uri = "stdlib/InteractiveUtils/#$"
+[[jl.function]]
+name = "InteractiveUtils.code_warntype"
+uri = "stdlib/InteractiveUtils/#$"
+[[jl.function]]
+name = "InteractiveUtils.define_editor"
+uri = "stdlib/InteractiveUtils/#$"
+[[jl.function]]
+name = "InteractiveUtils.methodswith"
+uri = "stdlib/InteractiveUtils/#$"
+[[jl.function]]
+name = "InteractiveUtils.subtypes"
+uri = "stdlib/InteractiveUtils/#$"
+[[jl.function]]
+name = "InteractiveUtils.supertypes"
+uri = "stdlib/InteractiveUtils/#$"
+[[jl.function]]
+name = "InteractiveUtils.varinfo"
+uri = "stdlib/InteractiveUtils/#$"
+[[jl.function]]
+name = "InteractiveUtils.versioninfo"
+uri = "stdlib/InteractiveUtils/#$"
+[[jl.function]]
+name = "LibGit2.GitRemoteAnon"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.GitRepoExt"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.add!"
+uri = "stdlib/LibGit2/#LibGit2.add%21"
+[[jl.function]]
+name = "LibGit2.add_fetch!"
+uri = "stdlib/LibGit2/#LibGit2.add_fetch%21"
+[[jl.function]]
+name = "LibGit2.add_push!"
+uri = "stdlib/LibGit2/#LibGit2.add_push%21"
+[[jl.function]]
+name = "LibGit2.addblob!"
+uri = "stdlib/LibGit2/#LibGit2.addblob%21"
+[[jl.function]]
+name = "LibGit2.addfile"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.approve"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.author"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.authors"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.branch"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.branch!"
+uri = "stdlib/LibGit2/#LibGit2.branch%21"
+[[jl.function]]
+name = "LibGit2.checkout!"
+uri = "stdlib/LibGit2/#LibGit2.checkout%21"
+[[jl.function]]
+name = "LibGit2.clone"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.commit"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.committer"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.count"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.counthunks"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.create_branch"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.credentials_callback"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.credentials_cb"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.default_signature"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.delete_branch"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.diff_files"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.entryid"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.entrytype"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.features"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.fetch"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.fetch_refspecs"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.fetchhead_foreach_cb"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.fetchheads"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.ffmerge!"
+uri = "stdlib/LibGit2/#LibGit2.ffmerge%21"
+[[jl.function]]
+name = "LibGit2.filemode"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.filename"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.fullname"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.git_url"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.gitdir"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.head"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.head!"
+uri = "stdlib/LibGit2/#LibGit2.head%21"
+[[jl.function]]
+name = "LibGit2.head_oid"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.headname"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.init"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.is_ancestor_of"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.isbinary"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.iscommit"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.isdiff"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.isdirty"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.isfilled"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.isorphan"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.isset"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.iszero"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.lookup_branch"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.map"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.merge_analysis"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.merge_base"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.message"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.mirror_callback"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.mirror_cb"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.name"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.need_update"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.objtype"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.path"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.peel"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.posixpath"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.push"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.push_head!"
+uri = "stdlib/LibGit2/#LibGit2.push_head%21"
+[[jl.function]]
+name = "LibGit2.push_refspecs"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.raw"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.read_tree!"
+uri = "stdlib/LibGit2/#LibGit2.read_tree%21"
+[[jl.function]]
+name = "LibGit2.rebase!"
+uri = "stdlib/LibGit2/#LibGit2.rebase%21"
+[[jl.function]]
+name = "LibGit2.ref_list"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.reftype"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.reject"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.remotes"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.remove!"
+uri = "stdlib/LibGit2/#LibGit2.remove%21"
+[[jl.function]]
+name = "LibGit2.reset"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.reset!"
+uri = "stdlib/LibGit2/#LibGit2.reset%21"
+[[jl.function]]
+name = "LibGit2.restore"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.revcount"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.set_remote_url"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.shortname"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.snapshot"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.split_cfg_entry"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.stage"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.status"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.tag_create"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.tag_delete"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.tag_list"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.target"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.toggle"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.transact"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.treewalk"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.update!"
+uri = "stdlib/LibGit2/#LibGit2.update%21"
+[[jl.function]]
+name = "LibGit2.upstream"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.url"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.version"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.with"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.with_warn"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LibGit2.workdir"
+uri = "stdlib/LibGit2/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.asum"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.blascopy!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.blascopy%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.dot"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.dotc"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.dotu"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.gbmv"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.gbmv!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.gbmv%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.gemm!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.gemm%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.gemv!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.gemv%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.ger!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.ger%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.get_num_threads"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.hemm!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.hemm%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.hemv!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.hemv%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.her!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.her%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.her2k"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.her2k!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.her2k%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.herk"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.herk!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.herk%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.hpmv!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.hpmv%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.iamax"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.nrm2"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.rot!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.rot%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.sbmv!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.sbmv%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.scal"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.scal!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.scal%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.set_num_threads"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.spmv!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.spmv%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.spr!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.spr%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.symm!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.symm%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.symv!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.symv%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.syr!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.syr%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.syr2k"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.syr2k!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.syr2k%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.syrk"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.syrk!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.syrk%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.trmm"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.trmm!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.trmm%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.trmv"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.trmv!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.trmv%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.trsm"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.trsm!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.trsm%21"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.trsv"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.BLAS.trsv!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.trsv%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.bdsdc!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.bdsdc%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.bdsqr!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.bdsqr%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gbtrf!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gbtrf%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gbtrs!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gbtrs%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gebak!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gebak%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gebal!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gebal%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gebrd!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gebrd%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gecon!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gecon%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gees!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gees%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.geev!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.geev%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.geevx!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.geevx%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gehrd!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gehrd%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gelqf!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gelqf%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gels!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gels%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gelsd!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gelsd%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gelsy!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gelsy%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gemqrt!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gemqrt%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.geqlf!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.geqlf%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.geqp3!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.geqp3%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.geqrf!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.geqrf%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.geqrt!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.geqrt%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.geqrt3!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.geqrt3%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gerqf!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gerqf%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gesdd!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gesdd%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gesv!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gesv%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gesvd!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gesvd%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gesvx!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gesvx%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.getrf!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.getrf%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.getri!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.getri%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.getrs!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.getrs%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gges!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gges%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gges3!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gges3%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.ggev!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.ggev%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.ggev3!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.ggev3%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gglse!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gglse%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.ggsvd!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.ggsvd%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.ggsvd3!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.ggsvd3%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gtsv!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gtsv%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gttrf!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gttrf%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.gttrs!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.gttrs%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.hesv!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.hesv%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.hetrf!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.hetrf%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.hetri!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.hetri%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.hetrs!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.hetrs%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.hseqr!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.hseqr%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.orghr!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.orghr%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.orglq!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.orglq%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.orgql!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.orgql%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.orgqr!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.orgqr%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.orgrq!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.orgrq%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.ormlq!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.ormlq%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.ormql!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.ormql%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.ormqr!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.ormqr%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.ormrq!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.ormrq%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.ormrz!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.ormrz%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.posv!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.posv%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.potrf!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.potrf%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.potri!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.potri%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.potrs!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.potrs%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.pstrf!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.pstrf%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.ptsv!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.ptsv%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.pttrf!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.pttrf%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.pttrs!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.pttrs%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.stebz!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.stebz%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.stegr!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.stegr%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.stein!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.stein%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.stev!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.stev%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.syconv!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.syconv%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.syev!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.syev%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.syevd!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.syevd%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.syevr!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.syevr%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.sygvd!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.sygvd%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.sysv!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.sysv%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.sytrf!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.sytrf%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.sytri!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.sytri%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.sytrs!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.sytrs%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.tgsen!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.tgsen%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.trcon!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.trcon%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.trevc!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.trevc%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.trexc!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.trexc%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.trrfs!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.trrfs%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.trsen!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.trsen%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.trsyl!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.trsyl%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.trtri!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.trtri%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.trtrs!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.trtrs%21"
+[[jl.function]]
+name = "LinearAlgebra.LAPACK.tzrzf!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.LAPACK.tzrzf%21"
+[[jl.function]]
+name = "LinearAlgebra.adjoint!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.adjoint%21"
+[[jl.function]]
+name = "LinearAlgebra.axpby!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.axpby%21"
+[[jl.function]]
+name = "LinearAlgebra.axpy!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.axpy%21"
+[[jl.function]]
+name = "LinearAlgebra.bunchkaufman"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.bunchkaufman!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.bunchkaufman%21"
+[[jl.function]]
+name = "LinearAlgebra.checksquare"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.cholesky"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.cholesky!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.cholesky%21"
+[[jl.function]]
+name = "LinearAlgebra.cond"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.condskeel"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.cross"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.det"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.diag"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.diagind"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.diagm"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.dot"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.eigen"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.eigen!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.eigen%21"
+[[jl.function]]
+name = "LinearAlgebra.eigmax"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.eigmin"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.eigvals"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.eigvals!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.eigvals%21"
+[[jl.function]]
+name = "LinearAlgebra.eigvecs"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.factorize"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.givens"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.hermitianpart"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.hermitianpart!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.hermitianpart%21"
+[[jl.function]]
+name = "LinearAlgebra.hessenberg"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.hessenberg!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.hessenberg%21"
+[[jl.function]]
+name = "LinearAlgebra.isdiag"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.ishermitian"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.isposdef"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.isposdef!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.isposdef%21"
+[[jl.function]]
+name = "LinearAlgebra.issuccess"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.issymmetric"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.istril"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.istriu"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.ldiv!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.ldiv%21"
+[[jl.function]]
+name = "LinearAlgebra.ldlt"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.ldlt!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.ldlt%21"
+[[jl.function]]
+name = "LinearAlgebra.lmul!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.lmul%21"
+[[jl.function]]
+name = "LinearAlgebra.logabsdet"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.logdet"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.lowrankdowndate"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.lowrankdowndate!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.lowrankdowndate%21"
+[[jl.function]]
+name = "LinearAlgebra.lowrankupdate"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.lowrankupdate!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.lowrankupdate%21"
+[[jl.function]]
+name = "LinearAlgebra.lq"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.lq!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.lq%21"
+[[jl.function]]
+name = "LinearAlgebra.lu"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.lu!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.lu%21"
+[[jl.function]]
+name = "LinearAlgebra.lyap"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.mul!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.mul%21"
+[[jl.function]]
+name = "LinearAlgebra.norm"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.normalize"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.normalize!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.normalize%21"
+[[jl.function]]
+name = "LinearAlgebra.nullspace"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.opnorm"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.ordschur"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.ordschur!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.ordschur%21"
+[[jl.function]]
+name = "LinearAlgebra.peakflops"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.pinv"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.qr"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.qr!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.qr%21"
+[[jl.function]]
+name = "LinearAlgebra.rank"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.rdiv!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.rdiv%21"
+[[jl.function]]
+name = "LinearAlgebra.reflect!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.reflect%21"
+[[jl.function]]
+name = "LinearAlgebra.rmul!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.rmul%21"
+[[jl.function]]
+name = "LinearAlgebra.rotate!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.rotate%21"
+[[jl.function]]
+name = "LinearAlgebra.schur"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.schur!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.schur%21"
+[[jl.function]]
+name = "LinearAlgebra.stride1"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.svd"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.svd!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.svd%21"
+[[jl.function]]
+name = "LinearAlgebra.svdvals"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.svdvals!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.svdvals%21"
+[[jl.function]]
+name = "LinearAlgebra.sylvester"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.tr"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.transpose!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.transpose%21"
+[[jl.function]]
+name = "LinearAlgebra.tril"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.tril!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.tril%21"
+[[jl.function]]
+name = "LinearAlgebra.triu"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.function]]
+name = "LinearAlgebra.triu!"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.triu%21"
+[[jl.function]]
+name = "Logging.catch_exceptions"
+uri = "stdlib/Logging/#$"
+[[jl.function]]
+name = "Logging.current_logger"
+uri = "stdlib/Logging/#$"
+[[jl.function]]
+name = "Logging.disable_logging"
+uri = "stdlib/Logging/#$"
+[[jl.function]]
+name = "Logging.global_logger"
+uri = "stdlib/Logging/#$"
+[[jl.function]]
+name = "Logging.handle_message"
+uri = "stdlib/Logging/#$"
+[[jl.function]]
+name = "Logging.min_enabled_level"
+uri = "stdlib/Logging/#$"
+[[jl.function]]
+name = "Logging.shouldlog"
+uri = "stdlib/Logging/#$"
+[[jl.function]]
+name = "Logging.with_logger"
+uri = "stdlib/Logging/#$"
+[[jl.function]]
+name = "Mmap.mmap"
+uri = "stdlib/Mmap/#$"
+[[jl.function]]
+name = "Mmap.sync!"
+uri = "stdlib/Mmap/#Mmap.sync%21"
+[[jl.function]]
+name = "NetworkOptions.ca_roots"
+uri = "stdlib/NetworkOptions/#$"
+[[jl.function]]
+name = "NetworkOptions.ca_roots_path"
+uri = "stdlib/NetworkOptions/#$"
+[[jl.function]]
+name = "NetworkOptions.ssh_dir"
+uri = "stdlib/NetworkOptions/#$"
+[[jl.function]]
+name = "NetworkOptions.ssh_key_name"
+uri = "stdlib/NetworkOptions/#$"
+[[jl.function]]
+name = "NetworkOptions.ssh_key_pass"
+uri = "stdlib/NetworkOptions/#$"
+[[jl.function]]
+name = "NetworkOptions.ssh_key_path"
+uri = "stdlib/NetworkOptions/#$"
+[[jl.function]]
+name = "NetworkOptions.ssh_known_hosts_file"
+uri = "stdlib/NetworkOptions/#$"
+[[jl.function]]
+name = "NetworkOptions.ssh_known_hosts_files"
+uri = "stdlib/NetworkOptions/#$"
+[[jl.function]]
+name = "NetworkOptions.ssh_pub_key_path"
+uri = "stdlib/NetworkOptions/#$"
+[[jl.function]]
+name = "NetworkOptions.verify_host"
+uri = "stdlib/NetworkOptions/#$"
+[[jl.function]]
+name = "Profile.Allocs.clear"
+uri = "stdlib/Profile/#$"
+[[jl.function]]
+name = "Profile.Allocs.fetch"
+uri = "stdlib/Profile/#$"
+[[jl.function]]
+name = "Profile.Allocs.start"
+uri = "stdlib/Profile/#$"
+[[jl.function]]
+name = "Profile.Allocs.stop"
+uri = "stdlib/Profile/#$"
+[[jl.function]]
+name = "Profile.callers"
+uri = "stdlib/Profile/#$"
+[[jl.function]]
+name = "Profile.clear"
+uri = "stdlib/Profile/#$"
+[[jl.function]]
+name = "Profile.clear_malloc_data"
+uri = "stdlib/Profile/#$"
+[[jl.function]]
+name = "Profile.fetch"
+uri = "stdlib/Profile/#$"
+[[jl.function]]
+name = "Profile.get_peek_duration"
+uri = "stdlib/Profile/#$"
+[[jl.function]]
+name = "Profile.init"
+uri = "stdlib/Profile/#$"
+[[jl.function]]
+name = "Profile.print"
+uri = "stdlib/Profile/#$"
+[[jl.function]]
+name = "Profile.retrieve"
+uri = "stdlib/Profile/#$"
+[[jl.function]]
+name = "Profile.set_peek_duration"
+uri = "stdlib/Profile/#$"
+[[jl.function]]
+name = "Profile.take_heap_snapshot"
+uri = "stdlib/Profile/#$"
+[[jl.function]]
+name = "REPL.TerminalMenus.cancel"
+uri = "stdlib/REPL/#$"
+[[jl.function]]
+name = "REPL.TerminalMenus.config"
+uri = "stdlib/REPL/#$"
+[[jl.function]]
+name = "REPL.TerminalMenus.header"
+uri = "stdlib/REPL/#$"
+[[jl.function]]
+name = "REPL.TerminalMenus.keypress"
+uri = "stdlib/REPL/#$"
+[[jl.function]]
+name = "REPL.TerminalMenus.numoptions"
+uri = "stdlib/REPL/#$"
+[[jl.function]]
+name = "REPL.TerminalMenus.options"
+uri = "stdlib/REPL/#$"
+[[jl.function]]
+name = "REPL.TerminalMenus.pick"
+uri = "stdlib/REPL/#$"
+[[jl.function]]
+name = "REPL.TerminalMenus.request"
+uri = "stdlib/REPL/#$"
+[[jl.function]]
+name = "REPL.TerminalMenus.selected"
+uri = "stdlib/REPL/#$"
+[[jl.function]]
+name = "REPL.TerminalMenus.writeline"
+uri = "stdlib/REPL/#$"
+[[jl.function]]
+name = "Random.bitrand"
+uri = "stdlib/Random/#$"
+[[jl.function]]
+name = "Random.default_rng"
+uri = "stdlib/Random/#$"
+[[jl.function]]
+name = "Random.rand!"
+uri = "stdlib/Random/#Random.rand%21"
+[[jl.function]]
+name = "Random.randcycle"
+uri = "stdlib/Random/#$"
+[[jl.function]]
+name = "Random.randcycle!"
+uri = "stdlib/Random/#Random.randcycle%21"
+[[jl.function]]
+name = "Random.randexp"
+uri = "stdlib/Random/#$"
+[[jl.function]]
+name = "Random.randexp!"
+uri = "stdlib/Random/#Random.randexp%21"
+[[jl.function]]
+name = "Random.randn!"
+uri = "stdlib/Random/#Random.randn%21"
+[[jl.function]]
+name = "Random.randperm"
+uri = "stdlib/Random/#$"
+[[jl.function]]
+name = "Random.randperm!"
+uri = "stdlib/Random/#Random.randperm%21"
+[[jl.function]]
+name = "Random.randstring"
+uri = "stdlib/Random/#$"
+[[jl.function]]
+name = "Random.randsubseq"
+uri = "stdlib/Random/#$"
+[[jl.function]]
+name = "Random.randsubseq!"
+uri = "stdlib/Random/#Random.randsubseq%21"
+[[jl.function]]
+name = "Random.seed!"
+uri = "stdlib/Random/#Random.seed%21"
+[[jl.function]]
+name = "Random.shuffle"
+uri = "stdlib/Random/#$"
+[[jl.function]]
+name = "Random.shuffle!"
+uri = "stdlib/Random/#Random.shuffle%21"
+[[jl.function]]
+name = "SHA.digest!"
+uri = "stdlib/SHA/#SHA.digest%21"
+[[jl.function]]
+name = "SHA.hmac_sha1"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.hmac_sha224"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.hmac_sha256"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.hmac_sha2_224"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.hmac_sha2_256"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.hmac_sha2_384"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.hmac_sha2_512"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.hmac_sha384"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.hmac_sha3_224"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.hmac_sha3_256"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.hmac_sha3_384"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.hmac_sha3_512"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.hmac_sha512"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.sha1"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.sha224"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.sha256"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.sha2_224"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.sha2_256"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.sha2_384"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.sha2_512"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.sha384"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.sha3_224"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.sha3_256"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.sha3_384"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.sha3_512"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.sha512"
+uri = "stdlib/SHA/#$"
+[[jl.function]]
+name = "SHA.update!"
+uri = "stdlib/SHA/#SHA.update%21"
+[[jl.function]]
+name = "Serialization.deserialize"
+uri = "stdlib/Serialization/#$"
+[[jl.function]]
+name = "Serialization.serialize"
+uri = "stdlib/Serialization/#$"
+[[jl.function]]
+name = "Serialization.writeheader"
+uri = "stdlib/Serialization/#$"
+[[jl.function]]
+name = "SharedArrays.indexpids"
+uri = "stdlib/SharedArrays/#$"
+[[jl.function]]
+name = "SharedArrays.localindices"
+uri = "stdlib/SharedArrays/#$"
+[[jl.function]]
+name = "SharedArrays.sdata"
+uri = "stdlib/SharedArrays/#$"
+[[jl.function]]
+name = "Sockets.accept"
+uri = "stdlib/Sockets/#$"
+[[jl.function]]
+name = "Sockets.getaddrinfo"
+uri = "stdlib/Sockets/#$"
+[[jl.function]]
+name = "Sockets.getalladdrinfo"
+uri = "stdlib/Sockets/#$"
+[[jl.function]]
+name = "Sockets.getipaddr"
+uri = "stdlib/Sockets/#$"
+[[jl.function]]
+name = "Sockets.getipaddrs"
+uri = "stdlib/Sockets/#$"
+[[jl.function]]
+name = "Sockets.getnameinfo"
+uri = "stdlib/Sockets/#$"
+[[jl.function]]
+name = "Sockets.getpeername"
+uri = "stdlib/Sockets/#$"
+[[jl.function]]
+name = "Sockets.getsockname"
+uri = "stdlib/Sockets/#$"
+[[jl.function]]
+name = "Sockets.islinklocaladdr"
+uri = "stdlib/Sockets/#$"
+[[jl.function]]
+name = "Sockets.listenany"
+uri = "stdlib/Sockets/#$"
+[[jl.function]]
+name = "Sockets.nagle"
+uri = "stdlib/Sockets/#$"
+[[jl.function]]
+name = "Sockets.quickack"
+uri = "stdlib/Sockets/#$"
+[[jl.function]]
+name = "Sockets.recv"
+uri = "stdlib/Sockets/#$"
+[[jl.function]]
+name = "Sockets.recvfrom"
+uri = "stdlib/Sockets/#$"
+[[jl.function]]
+name = "Sockets.send"
+uri = "stdlib/Sockets/#$"
+[[jl.function]]
+name = "Sockets.setopt"
+uri = "stdlib/Sockets/#$"
+[[jl.function]]
+name = "SparseArrays.blockdiag"
+uri = "stdlib/SparseArrays/#$"
+[[jl.function]]
+name = "SparseArrays.droptol!"
+uri = "stdlib/SparseArrays/#SparseArrays.droptol%21"
+[[jl.function]]
+name = "SparseArrays.dropzeros"
+uri = "stdlib/SparseArrays/#$"
+[[jl.function]]
+name = "SparseArrays.dropzeros!"
+uri = "stdlib/SparseArrays/#SparseArrays.dropzeros%21"
+[[jl.function]]
+name = "SparseArrays.findnz"
+uri = "stdlib/SparseArrays/#$"
+[[jl.function]]
+name = "SparseArrays.ftranspose!"
+uri = "stdlib/SparseArrays/#SparseArrays.ftranspose%21"
+[[jl.function]]
+name = "SparseArrays.halfperm!"
+uri = "stdlib/SparseArrays/#SparseArrays.halfperm%21"
+[[jl.function]]
+name = "SparseArrays.issparse"
+uri = "stdlib/SparseArrays/#$"
+[[jl.function]]
+name = "SparseArrays.nnz"
+uri = "stdlib/SparseArrays/#$"
+[[jl.function]]
+name = "SparseArrays.nonzeros"
+uri = "stdlib/SparseArrays/#$"
+[[jl.function]]
+name = "SparseArrays.nzrange"
+uri = "stdlib/SparseArrays/#$"
+[[jl.function]]
+name = "SparseArrays.permute"
+uri = "stdlib/SparseArrays/#$"
+[[jl.function]]
+name = "SparseArrays.rowvals"
+uri = "stdlib/SparseArrays/#$"
+[[jl.function]]
+name = "SparseArrays.sparse"
+uri = "stdlib/SparseArrays/#$"
+[[jl.function]]
+name = "SparseArrays.sparse!"
+uri = "stdlib/SparseArrays/#SparseArrays.sparse%21"
+[[jl.function]]
+name = "SparseArrays.sparse_hcat"
+uri = "stdlib/SparseArrays/#$"
+[[jl.function]]
+name = "SparseArrays.sparse_hvcat"
+uri = "stdlib/SparseArrays/#$"
+[[jl.function]]
+name = "SparseArrays.sparse_vcat"
+uri = "stdlib/SparseArrays/#$"
+[[jl.function]]
+name = "SparseArrays.sparsevec"
+uri = "stdlib/SparseArrays/#$"
+[[jl.function]]
+name = "SparseArrays.spdiagm"
+uri = "stdlib/SparseArrays/#$"
+[[jl.function]]
+name = "SparseArrays.sprand"
+uri = "stdlib/SparseArrays/#$"
+[[jl.function]]
+name = "SparseArrays.sprandn"
+uri = "stdlib/SparseArrays/#$"
+[[jl.function]]
+name = "SparseArrays.spzeros"
+uri = "stdlib/SparseArrays/#$"
+[[jl.function]]
+name = "SparseArrays.spzeros!"
+uri = "stdlib/SparseArrays/#SparseArrays.spzeros%21"
+[[jl.function]]
+name = "Statistics.cor"
+uri = "stdlib/Statistics/#$"
+[[jl.function]]
+name = "Statistics.cov"
+uri = "stdlib/Statistics/#$"
+[[jl.function]]
+name = "Statistics.mean"
+uri = "stdlib/Statistics/#$"
+[[jl.function]]
+name = "Statistics.mean!"
+uri = "stdlib/Statistics/#Statistics.mean%21"
+[[jl.function]]
+name = "Statistics.median"
+uri = "stdlib/Statistics/#$"
+[[jl.function]]
+name = "Statistics.median!"
+uri = "stdlib/Statistics/#Statistics.median%21"
+[[jl.function]]
+name = "Statistics.middle"
+uri = "stdlib/Statistics/#$"
+[[jl.function]]
+name = "Statistics.quantile"
+uri = "stdlib/Statistics/#$"
+[[jl.function]]
+name = "Statistics.quantile!"
+uri = "stdlib/Statistics/#Statistics.quantile%21"
+[[jl.function]]
+name = "Statistics.std"
+uri = "stdlib/Statistics/#$"
+[[jl.function]]
+name = "Statistics.stdm"
+uri = "stdlib/Statistics/#$"
+[[jl.function]]
+name = "Statistics.var"
+uri = "stdlib/Statistics/#$"
+[[jl.function]]
+name = "Statistics.varm"
+uri = "stdlib/Statistics/#$"
+[[jl.function]]
+name = "TOML.parse"
+uri = "stdlib/TOML/#$"
+[[jl.function]]
+name = "TOML.parsefile"
+uri = "stdlib/TOML/#$"
+[[jl.function]]
+name = "TOML.print"
+uri = "stdlib/TOML/#$"
+[[jl.function]]
+name = "TOML.tryparse"
+uri = "stdlib/TOML/#$"
+[[jl.function]]
+name = "TOML.tryparsefile"
+uri = "stdlib/TOML/#$"
+[[jl.function]]
+name = "Tar.create"
+uri = "stdlib/Tar/#$"
+[[jl.function]]
+name = "Tar.extract"
+uri = "stdlib/Tar/#$"
+[[jl.function]]
+name = "Tar.list"
+uri = "stdlib/Tar/#$"
+[[jl.function]]
+name = "Tar.rewrite"
+uri = "stdlib/Tar/#$"
+[[jl.function]]
+name = "Tar.tree_hash"
+uri = "stdlib/Tar/#$"
+[[jl.function]]
+name = "Test.detect_ambiguities"
+uri = "stdlib/Test/#$"
+[[jl.function]]
+name = "Test.detect_unbound_args"
+uri = "stdlib/Test/#$"
+[[jl.function]]
+name = "Test.finish"
+uri = "stdlib/Test/#$"
+[[jl.function]]
+name = "Test.get_testset"
+uri = "stdlib/Test/#$"
+[[jl.function]]
+name = "Test.get_testset_depth"
+uri = "stdlib/Test/#$"
+[[jl.function]]
+name = "Test.record"
+uri = "stdlib/Test/#$"
+[[jl.function]]
+name = "UUIDs.uuid1"
+uri = "stdlib/UUIDs/#$"
+[[jl.function]]
+name = "UUIDs.uuid4"
+uri = "stdlib/UUIDs/#$"
+[[jl.function]]
+name = "UUIDs.uuid5"
+uri = "stdlib/UUIDs/#$"
+[[jl.function]]
+name = "UUIDs.uuid_version"
+uri = "stdlib/UUIDs/#$"
+[[jl.function]]
+name = "Unicode.graphemes"
+uri = "stdlib/Unicode/#$"
+[[jl.function]]
+name = "Unicode.isassigned"
+uri = "stdlib/Unicode/#$"
+[[jl.function]]
+name = "Unicode.isequal_normalized"
+uri = "stdlib/Unicode/#$"
+[[jl.function]]
+name = "Unicode.julia_chartransform"
+uri = "stdlib/Unicode/#$"
+[[jl.function]]
+name = "Unicode.normalize"
+uri = "stdlib/Unicode/#$"
+
+[[jl.keyword]]
+name = "&&"
+uri = "base/math/#%26%26"
+[[jl.keyword]]
+name = "..."
+uri = "base/base/#$"
+[[jl.keyword]]
+name = ";"
+uri = "base/base/#%3B"
+[[jl.keyword]]
+name = "="
+uri = "base/base/#%3D"
+[[jl.keyword]]
+name = "?:"
+uri = "base/base/#%3F%3A"
+[[jl.keyword]]
+name = "Union{}"
+uri = "base/base/#Union%7B%7D"
+[[jl.keyword]]
+name = "__init__"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "__module__"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "__source__"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "abstract type"
+uri = "base/base/#abstract%20type"
+[[jl.keyword]]
+name = "as"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "atomic"
+uri = "base/multi-threading/#$"
+[[jl.keyword]]
+name = "baremodule"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "begin"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "break"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "ccall"
+uri = "base/c/#$"
+[[jl.keyword]]
+name = "const"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "continue"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "do"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "end"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "export"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "finally"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "for"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "function"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "global"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "if"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "import"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "let"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "local"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "macro"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "module"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "mutable struct"
+uri = "base/base/#mutable%20struct"
+[[jl.keyword]]
+name = "new"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "outer"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "primitive type"
+uri = "base/base/#primitive%20type"
+[[jl.keyword]]
+name = "quote"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "return"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "struct"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "try"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "using"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "var\"name\""
+uri = "base/base/#var%22name%22"
+[[jl.keyword]]
+name = "where"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "while"
+uri = "base/base/#$"
+[[jl.keyword]]
+name = "||"
+uri = "base/math/#%7C%7C"
+
+[[jl.macro]]
+name = "ArgTools.@arg_test"
+uri = "stdlib/ArgTools/#ArgTools.%40arg_test"
+[[jl.macro]]
+name = "Artifacts.@artifact_str"
+uri = "stdlib/Artifacts/#Artifacts.%40artifact_str"
+[[jl.macro]]
+name = "Base.@Kwargs"
+uri = "base/base/#Base.%40Kwargs"
+[[jl.macro]]
+name = "Base.@NamedTuple"
+uri = "base/base/#Base.%40NamedTuple"
+[[jl.macro]]
+name = "Base.@__DIR__"
+uri = "base/base/#Base.%40__DIR__"
+[[jl.macro]]
+name = "Base.@__FILE__"
+uri = "base/base/#Base.%40__FILE__"
+[[jl.macro]]
+name = "Base.@__LINE__"
+uri = "base/base/#Base.%40__LINE__"
+[[jl.macro]]
+name = "Base.@__MODULE__"
+uri = "base/base/#Base.%40__MODULE__"
+[[jl.macro]]
+name = "Base.@allocated"
+uri = "base/base/#Base.%40allocated"
+[[jl.macro]]
+name = "Base.@allocations"
+uri = "base/base/#Base.%40allocations"
+[[jl.macro]]
+name = "Base.@assert"
+uri = "base/base/#Base.%40assert"
+[[jl.macro]]
+name = "Base.@assume_effects"
+uri = "base/base/#Base.%40assume_effects"
+[[jl.macro]]
+name = "Base.@async"
+uri = "base/parallel/#Base.%40async"
+[[jl.macro]]
+name = "Base.@atomic"
+uri = "base/multi-threading/#Base.%40atomic"
+[[jl.macro]]
+name = "Base.@atomicreplace"
+uri = "base/multi-threading/#Base.%40atomicreplace"
+[[jl.macro]]
+name = "Base.@atomicswap"
+uri = "base/multi-threading/#Base.%40atomicswap"
+[[jl.macro]]
+name = "Base.@b_str"
+uri = "base/strings/#Base.%40b_str"
+[[jl.macro]]
+name = "Base.@boundscheck"
+uri = "base/base/#Base.%40boundscheck"
+[[jl.macro]]
+name = "Base.@ccall"
+uri = "base/c/#Base.%40ccall"
+[[jl.macro]]
+name = "Base.@cfunction"
+uri = "base/c/#Base.%40cfunction"
+[[jl.macro]]
+name = "Base.@coalesce"
+uri = "base/base/#Base.%40coalesce"
+[[jl.macro]]
+name = "Base.@constprop"
+uri = "base/base/#Base.%40constprop"
+[[jl.macro]]
+name = "Base.@deprecate"
+uri = "base/base/#Base.%40deprecate"
+[[jl.macro]]
+name = "Base.@elapsed"
+uri = "base/base/#Base.%40elapsed"
+[[jl.macro]]
+name = "Base.@eval"
+uri = "base/base/#Base.%40eval"
+[[jl.macro]]
+name = "Base.@generated"
+uri = "base/base/#Base.%40generated"
+[[jl.macro]]
+name = "Base.@gensym"
+uri = "base/base/#Base.%40gensym"
+[[jl.macro]]
+name = "Base.@goto"
+uri = "base/base/#Base.%40goto"
+[[jl.macro]]
+name = "Base.@inbounds"
+uri = "base/base/#Base.%40inbounds"
+[[jl.macro]]
+name = "Base.@inline"
+uri = "base/base/#Base.%40inline"
+[[jl.macro]]
+name = "Base.@invoke"
+uri = "base/base/#Base.%40invoke"
+[[jl.macro]]
+name = "Base.@invokelatest"
+uri = "base/base/#Base.%40invokelatest"
+[[jl.macro]]
+name = "Base.@isdefined"
+uri = "base/base/#Base.%40isdefined"
+[[jl.macro]]
+name = "Base.@kwdef"
+uri = "base/base/#Base.%40kwdef"
+[[jl.macro]]
+name = "Base.@label"
+uri = "base/base/#Base.%40label"
+[[jl.macro]]
+name = "Base.@lazy_str"
+uri = "base/strings/#Base.%40lazy_str"
+[[jl.macro]]
+name = "Base.@locals"
+uri = "base/base/#Base.%40locals"
+[[jl.macro]]
+name = "Base.@macroexpand"
+uri = "base/base/#Base.%40macroexpand"
+[[jl.macro]]
+name = "Base.@macroexpand1"
+uri = "base/base/#Base.%40macroexpand1"
+[[jl.macro]]
+name = "Base.@noinline"
+uri = "base/base/#Base.%40noinline"
+[[jl.macro]]
+name = "Base.@nospecialize"
+uri = "base/base/#Base.%40nospecialize"
+[[jl.macro]]
+name = "Base.@nospecializeinfer"
+uri = "base/base/#Base.%40nospecializeinfer"
+[[jl.macro]]
+name = "Base.@polly"
+uri = "base/base/#Base.%40polly"
+[[jl.macro]]
+name = "Base.@propagate_inbounds"
+uri = "base/base/#Base.%40propagate_inbounds"
+[[jl.macro]]
+name = "Base.@r_str"
+uri = "base/strings/#Base.%40r_str"
+[[jl.macro]]
+name = "Base.@raw_str"
+uri = "base/strings/#Base.%40raw_str"
+[[jl.macro]]
+name = "Base.@s_str"
+uri = "base/strings/#Base.%40s_str"
+[[jl.macro]]
+name = "Base.@show"
+uri = "base/base/#Base.%40show"
+[[jl.macro]]
+name = "Base.@showtime"
+uri = "base/base/#Base.%40showtime"
+[[jl.macro]]
+name = "Base.@something"
+uri = "base/base/#Base.%40something"
+[[jl.macro]]
+name = "Base.@specialize"
+uri = "base/base/#Base.%40specialize"
+[[jl.macro]]
+name = "Base.@static"
+uri = "base/base/#Base.%40static"
+[[jl.macro]]
+name = "Base.@sync"
+uri = "base/parallel/#Base.%40sync"
+[[jl.macro]]
+name = "Base.@task"
+uri = "base/parallel/#Base.%40task"
+[[jl.macro]]
+name = "Base.@threadcall"
+uri = "base/multi-threading/#Base.%40threadcall"
+[[jl.macro]]
+name = "Base.@time"
+uri = "base/base/#Base.%40time"
+[[jl.macro]]
+name = "Base.@timed"
+uri = "base/base/#Base.%40timed"
+[[jl.macro]]
+name = "Base.@timev"
+uri = "base/base/#Base.%40timev"
+[[jl.macro]]
+name = "Base.@v_str"
+uri = "base/base/#Base.%40v_str"
+[[jl.macro]]
+name = "Base.@view"
+uri = "base/arrays/#Base.%40view"
+[[jl.macro]]
+name = "Base.@views"
+uri = "base/arrays/#Base.%40views"
+[[jl.macro]]
+name = "Base.Broadcast.@__dot__"
+uri = "base/arrays/#Base.Broadcast.%40__dot__"
+[[jl.macro]]
+name = "Base.Cartesian.@nall"
+uri = "devdocs/cartesian/#Base.Cartesian.%40nall"
+[[jl.macro]]
+name = "Base.Cartesian.@nany"
+uri = "devdocs/cartesian/#Base.Cartesian.%40nany"
+[[jl.macro]]
+name = "Base.Cartesian.@ncall"
+uri = "devdocs/cartesian/#Base.Cartesian.%40ncall"
+[[jl.macro]]
+name = "Base.Cartesian.@nexprs"
+uri = "devdocs/cartesian/#Base.Cartesian.%40nexprs"
+[[jl.macro]]
+name = "Base.Cartesian.@nextract"
+uri = "devdocs/cartesian/#Base.Cartesian.%40nextract"
+[[jl.macro]]
+name = "Base.Cartesian.@nif"
+uri = "devdocs/cartesian/#Base.Cartesian.%40nif"
+[[jl.macro]]
+name = "Base.Cartesian.@nloops"
+uri = "devdocs/cartesian/#Base.Cartesian.%40nloops"
+[[jl.macro]]
+name = "Base.Cartesian.@nref"
+uri = "devdocs/cartesian/#Base.Cartesian.%40nref"
+[[jl.macro]]
+name = "Base.Cartesian.@ntuple"
+uri = "devdocs/cartesian/#Base.Cartesian.%40ntuple"
+[[jl.macro]]
+name = "Base.Docs.@html_str"
+uri = "base/strings/#Base.Docs.%40html_str"
+[[jl.macro]]
+name = "Base.Docs.@text_str"
+uri = "base/strings/#Base.Docs.%40text_str"
+[[jl.macro]]
+name = "Base.Enums.@enum"
+uri = "base/base/#Base.Enums.%40enum"
+[[jl.macro]]
+name = "Base.FastMath.@fastmath"
+uri = "base/math/#Base.FastMath.%40fastmath"
+[[jl.macro]]
+name = "Base.GC.@preserve"
+uri = "base/base/#Base.GC.%40preserve"
+[[jl.macro]]
+name = "Base.Math.@evalpoly"
+uri = "base/math/#Base.Math.%40evalpoly"
+[[jl.macro]]
+name = "Base.Meta.@dump"
+uri = "base/io-network/#Base.Meta.%40dump"
+[[jl.macro]]
+name = "Base.Meta.@lower"
+uri = "base/base/#Base.Meta.%40lower"
+[[jl.macro]]
+name = "Base.Multimedia.@MIME_str"
+uri = "base/io-network/#Base.Multimedia.%40MIME_str"
+[[jl.macro]]
+name = "Base.SimdLoop.@simd"
+uri = "base/base/#Base.SimdLoop.%40simd"
+[[jl.macro]]
+name = "Base.Threads.@spawn"
+uri = "base/multi-threading/#Base.Threads.%40spawn"
+[[jl.macro]]
+name = "Base.Threads.@threads"
+uri = "base/multi-threading/#Base.Threads.%40threads"
+[[jl.macro]]
+name = "Core.@__doc__"
+uri = "manual/documentation/#Core.%40__doc__"
+[[jl.macro]]
+name = "Core.@big_str"
+uri = "base/numbers/#Core.%40big_str"
+[[jl.macro]]
+name = "Core.@int128_str"
+uri = "base/numbers/#Core.%40int128_str"
+[[jl.macro]]
+name = "Core.@uint128_str"
+uri = "base/numbers/#Core.%40uint128_str"
+[[jl.macro]]
+name = "Dates.@dateformat_str"
+uri = "stdlib/Dates/#Dates.%40dateformat_str"
+[[jl.macro]]
+name = "Distributed.@distributed"
+uri = "stdlib/Distributed/#Distributed.%40distributed"
+[[jl.macro]]
+name = "Distributed.@everywhere"
+uri = "stdlib/Distributed/#Distributed.%40everywhere"
+[[jl.macro]]
+name = "Distributed.@fetch"
+uri = "stdlib/Distributed/#Distributed.%40fetch"
+[[jl.macro]]
+name = "Distributed.@fetchfrom"
+uri = "stdlib/Distributed/#Distributed.%40fetchfrom"
+[[jl.macro]]
+name = "Distributed.@spawnat"
+uri = "stdlib/Distributed/#Distributed.%40spawnat"
+[[jl.macro]]
+name = "InteractiveUtils.@code_llvm"
+uri = "stdlib/InteractiveUtils/#InteractiveUtils.%40code_llvm"
+[[jl.macro]]
+name = "InteractiveUtils.@code_lowered"
+uri = "stdlib/InteractiveUtils/#InteractiveUtils.%40code_lowered"
+[[jl.macro]]
+name = "InteractiveUtils.@code_native"
+uri = "stdlib/InteractiveUtils/#InteractiveUtils.%40code_native"
+[[jl.macro]]
+name = "InteractiveUtils.@code_typed"
+uri = "stdlib/InteractiveUtils/#InteractiveUtils.%40code_typed"
+[[jl.macro]]
+name = "InteractiveUtils.@code_warntype"
+uri = "stdlib/InteractiveUtils/#InteractiveUtils.%40code_warntype"
+[[jl.macro]]
+name = "InteractiveUtils.@edit"
+uri = "stdlib/InteractiveUtils/#InteractiveUtils.%40edit"
+[[jl.macro]]
+name = "InteractiveUtils.@functionloc"
+uri = "stdlib/InteractiveUtils/#InteractiveUtils.%40functionloc"
+[[jl.macro]]
+name = "InteractiveUtils.@less"
+uri = "stdlib/InteractiveUtils/#InteractiveUtils.%40less"
+[[jl.macro]]
+name = "InteractiveUtils.@time_imports"
+uri = "stdlib/InteractiveUtils/#InteractiveUtils.%40time_imports"
+[[jl.macro]]
+name = "InteractiveUtils.@which"
+uri = "stdlib/InteractiveUtils/#InteractiveUtils.%40which"
+[[jl.macro]]
+name = "LibGit2.@githash_str"
+uri = "stdlib/LibGit2/#LibGit2.%40githash_str"
+[[jl.macro]]
+name = "Logging.@logmsg"
+uri = "stdlib/Logging/#Logging.%40logmsg"
+[[jl.macro]]
+name = "Printf.@printf"
+uri = "stdlib/Printf/#Printf.%40printf"
+[[jl.macro]]
+name = "Printf.@sprintf"
+uri = "stdlib/Printf/#Printf.%40sprintf"
+[[jl.macro]]
+name = "Profile.@profile"
+uri = "stdlib/Profile/#Profile.%40profile"
+[[jl.macro]]
+name = "Profile.Allocs.@profile"
+uri = "stdlib/Profile/#Profile.Allocs.%40profile"
+[[jl.macro]]
+name = "Sockets.@ip_str"
+uri = "stdlib/Sockets/#Sockets.%40ip_str"
+[[jl.macro]]
+name = "Test.@inferred"
+uri = "stdlib/Test/#Test.%40inferred"
+[[jl.macro]]
+name = "Test.@test"
+uri = "stdlib/Test/#Test.%40test"
+[[jl.macro]]
+name = "Test.@test_broken"
+uri = "stdlib/Test/#Test.%40test_broken"
+[[jl.macro]]
+name = "Test.@test_deprecated"
+uri = "stdlib/Test/#Test.%40test_deprecated"
+[[jl.macro]]
+name = "Test.@test_logs"
+uri = "stdlib/Test/#Test.%40test_logs"
+[[jl.macro]]
+name = "Test.@test_nowarn"
+uri = "stdlib/Test/#Test.%40test_nowarn"
+[[jl.macro]]
+name = "Test.@test_skip"
+uri = "stdlib/Test/#Test.%40test_skip"
+[[jl.macro]]
+name = "Test.@test_throws"
+uri = "stdlib/Test/#Test.%40test_throws"
+[[jl.macro]]
+name = "Test.@test_warn"
+uri = "stdlib/Test/#Test.%40test_warn"
+[[jl.macro]]
+name = "Test.@testset"
+uri = "stdlib/Test/#Test.%40testset"
+
+[[jl.method]]
+name = "Base.:*-Tuple{AbstractMatrix, AbstractMatrix}"
+uri = "stdlib/LinearAlgebra/#Base.%3A%2A-Tuple%7BAbstractMatrix%2C%20AbstractMatrix%7D"
+[[jl.method]]
+name = "Base.:*-Tuple{Any, Vararg{Any}}"
+uri = "base/math/#Base.%3A%2A-Tuple%7BAny%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "Base.:*-Tuple{Union{AbstractChar, AbstractString}, Vararg{Union{AbstractChar, AbstractString}}}"
+uri = "base/strings/#Base.%3A%2A-Tuple%7BUnion%7BAbstractChar%2C%20AbstractString%7D%2C%20Vararg%7BUnion%7BAbstractChar%2C%20AbstractString%7D%7D%7D"
+[[jl.method]]
+name = "Base.:--Tuple{Any, Any}"
+uri = "base/math/#Base.%3A--Tuple%7BAny%2C%20Any%7D"
+[[jl.method]]
+name = "Base.:--Tuple{Any}"
+uri = "base/math/#Base.%3A--Tuple%7BAny%7D"
+[[jl.method]]
+name = "Base.:/-Tuple{AbstractVecOrMat, AbstractVecOrMat}"
+uri = "stdlib/LinearAlgebra/#Base.%3A%2F-Tuple%7BAbstractVecOrMat%2C%20AbstractVecOrMat%7D"
+[[jl.method]]
+name = "Base.:==-Tuple{AbstractString, AbstractString}"
+uri = "base/strings/#Base.%3A%3D%3D-Tuple%7BAbstractString%2C%20AbstractString%7D"
+[[jl.method]]
+name = "Base.:\\-Tuple{AbstractMatrix, AbstractVecOrMat}"
+uri = "stdlib/LinearAlgebra/#Base.%3A%5C-Tuple%7BAbstractMatrix%2C%20AbstractVecOrMat%7D"
+[[jl.method]]
+name = "Base.:\\-Tuple{Any, Any}"
+uri = "base/math/#Base.%3A%5C-Tuple%7BAny%2C%20Any%7D"
+[[jl.method]]
+name = "Base.:^-Tuple{AbstractMatrix, Number}"
+uri = "stdlib/LinearAlgebra/#Base.%3A%5E-Tuple%7BAbstractMatrix%2C%20Number%7D"
+[[jl.method]]
+name = "Base.:^-Tuple{Number, AbstractMatrix}"
+uri = "stdlib/LinearAlgebra/#Base.%3A%5E-Tuple%7BNumber%2C%20AbstractMatrix%7D"
+[[jl.method]]
+name = "Base.:^-Tuple{Number, Number}"
+uri = "base/math/#Base.%3A%5E-Tuple%7BNumber%2C%20Number%7D"
+[[jl.method]]
+name = "Base.:^-Tuple{Union{AbstractChar, AbstractString}, Integer}"
+uri = "base/strings/#Base.%3A%5E-Tuple%7BUnion%7BAbstractChar%2C%20AbstractString%7D%2C%20Integer%7D"
+[[jl.method]]
+name = "Base.AsyncCondition-Tuple{Function}"
+uri = "base/base/#Base.AsyncCondition-Tuple%7BFunction%7D"
+[[jl.method]]
+name = "Base.BitArray-Tuple{Any}"
+uri = "base/arrays/#Base.BitArray-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Base.BitArray-Tuple{UndefInitializer, Vararg{Integer}}"
+uri = "base/arrays/#Base.BitArray-Tuple%7BUndefInitializer%2C%20Vararg%7BInteger%7D%7D"
+[[jl.method]]
+name = "Base.Channel-Tuple{Function}"
+uri = "base/parallel/#Base.Channel-Tuple%7BFunction%7D"
+[[jl.method]]
+name = "Base.Filesystem.cd-Tuple{AbstractString}"
+uri = "base/file/#Base.Filesystem.cd-Tuple%7BAbstractString%7D"
+[[jl.method]]
+name = "Base.Filesystem.cd-Tuple{Function}"
+uri = "base/file/#Base.Filesystem.cd-Tuple%7BFunction%7D"
+[[jl.method]]
+name = "Base.Filesystem.mktemp-Tuple{AbstractString}"
+uri = "base/file/#Base.Filesystem.mktemp-Tuple%7BAbstractString%7D"
+[[jl.method]]
+name = "Base.Filesystem.mktemp-Tuple{Function, AbstractString}"
+uri = "base/file/#Base.Filesystem.mktemp-Tuple%7BFunction%2C%20AbstractString%7D"
+[[jl.method]]
+name = "Base.Filesystem.mktempdir-Tuple{AbstractString}"
+uri = "base/file/#Base.Filesystem.mktempdir-Tuple%7BAbstractString%7D"
+[[jl.method]]
+name = "Base.Filesystem.mktempdir-Tuple{Function, AbstractString}"
+uri = "base/file/#Base.Filesystem.mktempdir-Tuple%7BFunction%2C%20AbstractString%7D"
+[[jl.method]]
+name = "Base.Filesystem.touch-Tuple{FileWatching.Pidfile.LockMonitor}"
+uri = "stdlib/FileWatching/#Base.Filesystem.touch-Tuple%7BFileWatching.Pidfile.LockMonitor%7D"
+[[jl.method]]
+name = "Base.GMP.BigInt-Tuple{Any}"
+uri = "base/numbers/#Base.GMP.BigInt-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Base.IOContext-Tuple{IO, IOContext}"
+uri = "base/io-network/#Base.IOContext-Tuple%7BIO%2C%20IOContext%7D"
+[[jl.method]]
+name = "Base.IOContext-Tuple{IO, Pair}"
+uri = "base/io-network/#Base.IOContext-Tuple%7BIO%2C%20Pair%7D"
+[[jl.method]]
+name = "Base.Libc.time-Tuple{Base.Libc.TmStruct}"
+uri = "base/libc/#Base.Libc.time-Tuple%7BBase.Libc.TmStruct%7D"
+[[jl.method]]
+name = "Base.Libc.time-Tuple{}"
+uri = "base/base/#Base.Libc.time-Tuple%7B%7D"
+[[jl.method]]
+name = "Base.MPFR.BigFloat-Tuple{Any, RoundingMode}"
+uri = "base/numbers/#Base.MPFR.BigFloat-Tuple%7BAny%2C%20RoundingMode%7D"
+[[jl.method]]
+name = "Base.Math.acot-Tuple{Number}"
+uri = "base/math/#Base.Math.acot-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.Math.acot-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.Math.acot-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.Math.acoth-Tuple{Number}"
+uri = "base/math/#Base.Math.acoth-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.Math.acoth-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.Math.acoth-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.Math.acsc-Tuple{Number}"
+uri = "base/math/#Base.Math.acsc-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.Math.acsc-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.Math.acsc-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.Math.acsch-Tuple{Number}"
+uri = "base/math/#Base.Math.acsch-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.Math.acsch-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.Math.acsch-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.Math.asec-Tuple{Number}"
+uri = "base/math/#Base.Math.asec-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.Math.asec-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.Math.asec-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.Math.asech-Tuple{Number}"
+uri = "base/math/#Base.Math.asech-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.Math.asech-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.Math.asech-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.Math.cot-Tuple{Number}"
+uri = "base/math/#Base.Math.cot-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.Math.cot-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.Math.cot-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.Math.coth-Tuple{Number}"
+uri = "base/math/#Base.Math.coth-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.Math.coth-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.Math.coth-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.Math.csc-Tuple{Number}"
+uri = "base/math/#Base.Math.csc-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.Math.csc-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.Math.csc-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.Math.csch-Tuple{Number}"
+uri = "base/math/#Base.Math.csch-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.Math.csch-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.Math.csch-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.Math.sec-Tuple{Number}"
+uri = "base/math/#Base.Math.sec-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.Math.sec-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.Math.sec-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.Math.sech-Tuple{Number}"
+uri = "base/math/#Base.Math.sech-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.Math.sech-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.Math.sech-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.Math.sincos-Tuple{Float64}"
+uri = "base/math/#Base.Math.sincos-Tuple%7BFloat64%7D"
+[[jl.method]]
+name = "Base.Math.sincos-Tuple{StridedMatrix{var\"#s51\"} where var\"#s51\"<:Real}"
+uri = "stdlib/LinearAlgebra/#Base.Math.sincos-Tuple%7BStridedMatrix%7Bvar%22%23s51%22%7D%20where%20var%22%23s51%22%3C%3AReal%7D"
+[[jl.method]]
+name = "Base.Matrix-Tuple{Missing, Any, Any}"
+uri = "base/arrays/#Base.Matrix-Tuple%7BMissing%2C%20Any%2C%20Any%7D"
+[[jl.method]]
+name = "Base.Matrix-Tuple{Nothing, Any, Any}"
+uri = "base/arrays/#Base.Matrix-Tuple%7BNothing%2C%20Any%2C%20Any%7D"
+[[jl.method]]
+name = "Base.Matrix-Tuple{UndefInitializer, Any, Any}"
+uri = "base/arrays/#Base.Matrix-Tuple%7BUndefInitializer%2C%20Any%2C%20Any%7D"
+[[jl.method]]
+name = "Base.Meta.parse-Tuple{AbstractString, Int64}"
+uri = "base/base/#Base.Meta.parse-Tuple%7BAbstractString%2C%20Int64%7D"
+[[jl.method]]
+name = "Base.Meta.parse-Tuple{AbstractString}"
+uri = "base/base/#Base.Meta.parse-Tuple%7BAbstractString%7D"
+[[jl.method]]
+name = "Base.Rounding.setrounding-Tuple{Function, Type, RoundingMode}"
+uri = "base/numbers/#Base.Rounding.setrounding-Tuple%7BFunction%2C%20Type%2C%20RoundingMode%7D"
+[[jl.method]]
+name = "Base.Rounding.setrounding-Tuple{Type, Any}"
+uri = "base/numbers/#Base.Rounding.setrounding-Tuple%7BType%2C%20Any%7D"
+[[jl.method]]
+name = "Base.Timer-Tuple{Function, Real}"
+uri = "base/base/#Base.Timer-Tuple%7BFunction%2C%20Real%7D"
+[[jl.method]]
+name = "Base.Vector-Tuple{Missing, Any}"
+uri = "base/arrays/#Base.Vector-Tuple%7BMissing%2C%20Any%7D"
+[[jl.method]]
+name = "Base.Vector-Tuple{Nothing, Any}"
+uri = "base/arrays/#Base.Vector-Tuple%7BNothing%2C%20Any%7D"
+[[jl.method]]
+name = "Base.Vector-Tuple{UndefInitializer, Any}"
+uri = "base/arrays/#Base.Vector-Tuple%7BUndefInitializer%2C%20Any%7D"
+[[jl.method]]
+name = "Base.acos-Tuple{Number}"
+uri = "base/math/#Base.acos-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.acos-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.acos-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.acosh-Tuple{Number}"
+uri = "base/math/#Base.acosh-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.acosh-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.acosh-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.all-Tuple{AbstractArray, Any}"
+uri = "base/collections/#Base.all-Tuple%7BAbstractArray%2C%20Any%7D"
+[[jl.method]]
+name = "Base.all-Tuple{Any}"
+uri = "base/collections/#Base.all-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Base.any-Tuple{AbstractArray, Any}"
+uri = "base/collections/#Base.any-Tuple%7BAbstractArray%2C%20Any%7D"
+[[jl.method]]
+name = "Base.any-Tuple{Any}"
+uri = "base/collections/#Base.any-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Base.asin-Tuple{Number}"
+uri = "base/math/#Base.asin-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.asin-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.asin-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.asinh-Tuple{Number}"
+uri = "base/math/#Base.asinh-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.asinh-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.asinh-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.atan-Tuple{Number}"
+uri = "base/math/#Base.atan-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.atan-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.atan-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.atanh-Tuple{Number}"
+uri = "base/math/#Base.atanh-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.atanh-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.atanh-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.axes-Tuple{AbstractArray, Any}"
+uri = "base/arrays/#Base.axes-Tuple%7BAbstractArray%2C%20Any%7D"
+[[jl.method]]
+name = "Base.axes-Tuple{Any}"
+uri = "base/arrays/#Base.axes-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Base.bind-Tuple{Channel, Task}"
+uri = "base/parallel/#Base.bind-Tuple%7BChannel%2C%20Task%7D"
+[[jl.method]]
+name = "Base.ceil-Tuple{TimeType, Period}"
+uri = "stdlib/Dates/#Base.ceil-Tuple%7BTimeType%2C%20Period%7D"
+[[jl.method]]
+name = "Base.ceil-Tuple{Union{Day, Week, TimePeriod}, Union{Day, Week, TimePeriod}}"
+uri = "stdlib/Dates/#Base.ceil-Tuple%7BUnion%7BDay%2C%20Week%2C%20TimePeriod%7D%2C%20Union%7BDay%2C%20Week%2C%20TimePeriod%7D%7D"
+[[jl.method]]
+name = "Base.cis-Tuple{AbstractMatrix}"
+uri = "stdlib/LinearAlgebra/#Base.cis-Tuple%7BAbstractMatrix%7D"
+[[jl.method]]
+name = "Base.close-Tuple{Channel}"
+uri = "base/parallel/#Base.close-Tuple%7BChannel%7D"
+[[jl.method]]
+name = "Base.close-Tuple{FileWatching.Pidfile.LockMonitor}"
+uri = "stdlib/FileWatching/#Base.close-Tuple%7BFileWatching.Pidfile.LockMonitor%7D"
+[[jl.method]]
+name = "Base.cmp-Tuple{AbstractString, AbstractString}"
+uri = "base/strings/#Base.cmp-Tuple%7BAbstractString%2C%20AbstractString%7D"
+[[jl.method]]
+name = "Base.collect-Tuple{Any}"
+uri = "base/collections/#Base.collect-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Base.collect-Tuple{Type, Any}"
+uri = "base/collections/#Base.collect-Tuple%7BType%2C%20Any%7D"
+[[jl.method]]
+name = "Base.complex-Tuple{Complex}"
+uri = "base/numbers/#Base.complex-Tuple%7BComplex%7D"
+[[jl.method]]
+name = "Base.copy-Tuple{Union{Adjoint, Transpose}}"
+uri = "stdlib/LinearAlgebra/#Base.copy-Tuple%7BUnion%7BAdjoint%2C%20Transpose%7D%7D"
+[[jl.method]]
+name = "Base.copyto!-Tuple{AbstractArray, CartesianIndices, AbstractArray, CartesianIndices}"
+uri = "base/arrays/#Base.copyto%21-Tuple%7BAbstractArray%2C%20CartesianIndices%2C%20AbstractArray%2C%20CartesianIndices%7D"
+[[jl.method]]
+name = "Base.cos-Tuple{Number}"
+uri = "base/math/#Base.cos-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.cos-Tuple{StridedMatrix{var\"#s51\"} where var\"#s51\"<:Real}"
+uri = "stdlib/LinearAlgebra/#Base.cos-Tuple%7BStridedMatrix%7Bvar%22%23s51%22%7D%20where%20var%22%23s51%22%3C%3AReal%7D"
+[[jl.method]]
+name = "Base.cosh-Tuple{Number}"
+uri = "base/math/#Base.cosh-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.cosh-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.cosh-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.eps-Tuple{AbstractFloat}"
+uri = "base/base/#Base.eps-Tuple%7BAbstractFloat%7D"
+[[jl.method]]
+name = "Base.eps-Tuple{Type{<:AbstractFloat}}"
+uri = "base/base/#Base.eps-Tuple%7BType%7B%3C%3AAbstractFloat%7D%7D"
+[[jl.method]]
+name = "Base.eps-Tuple{Union{Type{Date}, Type{DateTime}, Type{Time}, TimeType}}"
+uri = "stdlib/Dates/#Base.eps-Tuple%7BUnion%7BType%7BDate%7D%2C%20Type%7BDateTime%7D%2C%20Type%7BTime%7D%2C%20TimeType%7D%7D"
+[[jl.method]]
+name = "Base.exp-Tuple{Float64}"
+uri = "base/math/#Base.exp-Tuple%7BFloat64%7D"
+[[jl.method]]
+name = "Base.exp-Tuple{StridedMatrix{var\"#s51\"} where var\"#s51\"<:Union{Float32, Float64, ComplexF64, ComplexF32}}"
+uri = "stdlib/LinearAlgebra/#Base.exp-Tuple%7BStridedMatrix%7Bvar%22%23s51%22%7D%20where%20var%22%23s51%22%3C%3AUnion%7BFloat32%2C%20Float64%2C%20ComplexF64%2C%20ComplexF32%7D%7D"
+[[jl.method]]
+name = "Base.fetch-Tuple{Any}"
+uri = "base/parallel/#Base.fetch-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Base.fetch-Tuple{Channel}"
+uri = "base/parallel/#Base.fetch-Tuple%7BChannel%7D"
+[[jl.method]]
+name = "Base.fetch-Tuple{Distributed.Future}"
+uri = "stdlib/Distributed/#Base.fetch-Tuple%7BDistributed.Future%7D"
+[[jl.method]]
+name = "Base.fetch-Tuple{RemoteChannel}"
+uri = "stdlib/Distributed/#Base.fetch-Tuple%7BRemoteChannel%7D"
+[[jl.method]]
+name = "Base.fetch-Tuple{Task}"
+uri = "base/parallel/#Base.fetch-Tuple%7BTask%7D"
+[[jl.method]]
+name = "Base.findall-Tuple{Any}"
+uri = "base/arrays/#Base.findall-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Base.findall-Tuple{Function, Any}"
+uri = "base/arrays/#Base.findall-Tuple%7BFunction%2C%20Any%7D"
+[[jl.method]]
+name = "Base.findfirst-Tuple{AbstractString, AbstractString}"
+uri = "base/strings/#Base.findfirst-Tuple%7BAbstractString%2C%20AbstractString%7D"
+[[jl.method]]
+name = "Base.findfirst-Tuple{Any}"
+uri = "base/arrays/#Base.findfirst-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Base.findfirst-Tuple{Function, Any}"
+uri = "base/arrays/#Base.findfirst-Tuple%7BFunction%2C%20Any%7D"
+[[jl.method]]
+name = "Base.findlast-Tuple{AbstractChar, AbstractString}"
+uri = "base/strings/#Base.findlast-Tuple%7BAbstractChar%2C%20AbstractString%7D"
+[[jl.method]]
+name = "Base.findlast-Tuple{AbstractString, AbstractString}"
+uri = "base/strings/#Base.findlast-Tuple%7BAbstractString%2C%20AbstractString%7D"
+[[jl.method]]
+name = "Base.findlast-Tuple{Any}"
+uri = "base/arrays/#Base.findlast-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Base.findlast-Tuple{Function, Any}"
+uri = "base/arrays/#Base.findlast-Tuple%7BFunction%2C%20Any%7D"
+[[jl.method]]
+name = "Base.findnext-Tuple{AbstractChar, AbstractString, Integer}"
+uri = "base/strings/#Base.findnext-Tuple%7BAbstractChar%2C%20AbstractString%2C%20Integer%7D"
+[[jl.method]]
+name = "Base.findnext-Tuple{AbstractString, AbstractString, Integer}"
+uri = "base/strings/#Base.findnext-Tuple%7BAbstractString%2C%20AbstractString%2C%20Integer%7D"
+[[jl.method]]
+name = "Base.findnext-Tuple{Any, Integer}"
+uri = "base/arrays/#Base.findnext-Tuple%7BAny%2C%20Integer%7D"
+[[jl.method]]
+name = "Base.findnext-Tuple{Function, Any, Integer}"
+uri = "base/arrays/#Base.findnext-Tuple%7BFunction%2C%20Any%2C%20Integer%7D"
+[[jl.method]]
+name = "Base.findprev-Tuple{AbstractString, AbstractString, Integer}"
+uri = "base/strings/#Base.findprev-Tuple%7BAbstractString%2C%20AbstractString%2C%20Integer%7D"
+[[jl.method]]
+name = "Base.findprev-Tuple{Any, Integer}"
+uri = "base/arrays/#Base.findprev-Tuple%7BAny%2C%20Integer%7D"
+[[jl.method]]
+name = "Base.findprev-Tuple{Function, Any, Integer}"
+uri = "base/arrays/#Base.findprev-Tuple%7BFunction%2C%20Any%2C%20Integer%7D"
+[[jl.method]]
+name = "Base.first-Tuple{AbstractString, Integer}"
+uri = "base/strings/#Base.first-Tuple%7BAbstractString%2C%20Integer%7D"
+[[jl.method]]
+name = "Base.float-Tuple{Any}"
+uri = "base/numbers/#Base.float-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Base.floor-Tuple{TimeType, Period}"
+uri = "stdlib/Dates/#Base.floor-Tuple%7BTimeType%2C%20Period%7D"
+[[jl.method]]
+name = "Base.floor-Union{Tuple{T}, Tuple{Union{Day, Week, TimePeriod}, T}} where T<:Union{Day, Week, TimePeriod}"
+uri = "stdlib/Dates/#Base.floor-Union%7BTuple%7BT%7D%2C%20Tuple%7BUnion%7BDay%2C%20Week%2C%20TimePeriod%7D%2C%20T%7D%7D%20where%20T%3C%3AUnion%7BDay%2C%20Week%2C%20TimePeriod%7D"
+[[jl.method]]
+name = "Base.foldl-Tuple{Any, Any}"
+uri = "base/collections/#Base.foldl-Tuple%7BAny%2C%20Any%7D"
+[[jl.method]]
+name = "Base.foldr-Tuple{Any, Any}"
+uri = "base/collections/#Base.foldr-Tuple%7BAny%2C%20Any%7D"
+[[jl.method]]
+name = "Base.functionloc-Tuple{Any, Any}"
+uri = "base/base/#Base.functionloc-Tuple%7BAny%2C%20Any%7D"
+[[jl.method]]
+name = "Base.functionloc-Tuple{Method}"
+uri = "base/base/#Base.functionloc-Tuple%7BMethod%7D"
+[[jl.method]]
+name = "Base.getindex-Tuple{AbstractArray, Vararg{Any}}"
+uri = "base/arrays/#Base.getindex-Tuple%7BAbstractArray%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "Base.getindex-Tuple{Type, Vararg{Any}}"
+uri = "base/arrays/#Base.getindex-Tuple%7BType%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "Base.inv-Tuple{AbstractMatrix}"
+uri = "stdlib/LinearAlgebra/#Base.inv-Tuple%7BAbstractMatrix%7D"
+[[jl.method]]
+name = "Base.inv-Tuple{Number}"
+uri = "base/math/#Base.inv-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.isassigned-Tuple{Base.RefValue}"
+uri = "base/c/#Base.isassigned-Tuple%7BBase.RefValue%7D"
+[[jl.method]]
+name = "Base.isless-Tuple{AbstractString, AbstractString}"
+uri = "base/strings/#Base.isless-Tuple%7BAbstractString%2C%20AbstractString%7D"
+[[jl.method]]
+name = "Base.isready-Tuple{Channel}"
+uri = "base/parallel/#Base.isready-Tuple%7BChannel%7D"
+[[jl.method]]
+name = "Base.isready-Tuple{Distributed.Future}"
+uri = "stdlib/Distributed/#Base.isready-Tuple%7BDistributed.Future%7D"
+[[jl.method]]
+name = "Base.isready-Tuple{RemoteChannel, Vararg{Any}}"
+uri = "stdlib/Distributed/#Base.isready-Tuple%7BRemoteChannel%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "Base.isvalid-Tuple{AbstractString, Integer}"
+uri = "base/strings/#Base.isvalid-Tuple%7BAbstractString%2C%20Integer%7D"
+[[jl.method]]
+name = "Base.isvalid-Tuple{Any, Any}"
+uri = "base/strings/#Base.isvalid-Tuple%7BAny%2C%20Any%7D"
+[[jl.method]]
+name = "Base.isvalid-Tuple{Any}"
+uri = "base/strings/#Base.isvalid-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Base.keys-Tuple{AbstractArray}"
+uri = "base/arrays/#Base.keys-Tuple%7BAbstractArray%7D"
+[[jl.method]]
+name = "Base.keys-Tuple{RegexMatch}"
+uri = "base/strings/#Base.keys-Tuple%7BRegexMatch%7D"
+[[jl.method]]
+name = "Base.kill-Tuple{Base.Process, Integer}"
+uri = "base/base/#Base.kill-Tuple%7BBase.Process%2C%20Integer%7D"
+[[jl.method]]
+name = "Base.kill-Tuple{ClusterManager, Int64, WorkerConfig}"
+uri = "stdlib/Distributed/#Base.kill-Tuple%7BClusterManager%2C%20Int64%2C%20WorkerConfig%7D"
+[[jl.method]]
+name = "Base.last-Tuple{AbstractString, Integer}"
+uri = "base/strings/#Base.last-Tuple%7BAbstractString%2C%20Integer%7D"
+[[jl.method]]
+name = "Base.length-Tuple{AbstractArray}"
+uri = "base/arrays/#Base.length-Tuple%7BAbstractArray%7D"
+[[jl.method]]
+name = "Base.length-Tuple{AbstractString}"
+uri = "base/strings/#Base.length-Tuple%7BAbstractString%7D"
+[[jl.method]]
+name = "Base.log-Tuple{Number, Number}"
+uri = "base/math/#Base.log-Tuple%7BNumber%2C%20Number%7D"
+[[jl.method]]
+name = "Base.log-Tuple{Number}"
+uri = "base/math/#Base.log-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.log-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.log-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.mapfoldl-Tuple{Any, Any, Any}"
+uri = "base/collections/#Base.mapfoldl-Tuple%7BAny%2C%20Any%2C%20Any%7D"
+[[jl.method]]
+name = "Base.mapfoldr-Tuple{Any, Any, Any}"
+uri = "base/collections/#Base.mapfoldr-Tuple%7BAny%2C%20Any%2C%20Any%7D"
+[[jl.method]]
+name = "Base.mapreduce-Tuple{Any, Any, Any}"
+uri = "base/collections/#Base.mapreduce-Tuple%7BAny%2C%20Any%2C%20Any%7D"
+[[jl.method]]
+name = "Base.nameof-Tuple{DataType}"
+uri = "base/base/#Base.nameof-Tuple%7BDataType%7D"
+[[jl.method]]
+name = "Base.nameof-Tuple{Function}"
+uri = "base/base/#Base.nameof-Tuple%7BFunction%7D"
+[[jl.method]]
+name = "Base.nameof-Tuple{Module}"
+uri = "base/base/#Base.nameof-Tuple%7BModule%7D"
+[[jl.method]]
+name = "Base.ncodeunits-Tuple{AbstractString}"
+uri = "base/strings/#Base.ncodeunits-Tuple%7BAbstractString%7D"
+[[jl.method]]
+name = "Base.pathof-Tuple{Module}"
+uri = "base/base/#Base.pathof-Tuple%7BModule%7D"
+[[jl.method]]
+name = "Base.permute!-Tuple{Any, AbstractVector}"
+uri = "base/arrays/#Base.permute%21-Tuple%7BAny%2C%20AbstractVector%7D"
+[[jl.method]]
+name = "Base.permute!-Union{Tuple{Tq}, Tuple{Tp}, Tuple{Ti}, Tuple{Tv}, Tuple{SparseMatrixCSC{Tv, Ti}, SparseMatrixCSC{Tv, Ti}, AbstractVector{Tp}, AbstractVector{Tq}}} where {Tv, Ti, Tp<:Integer, Tq<:Integer}"
+uri = "stdlib/SparseArrays/#Base.permute%21-Union%7BTuple%7BTq%7D%2C%20Tuple%7BTp%7D%2C%20Tuple%7BTi%7D%2C%20Tuple%7BTv%7D%2C%20Tuple%7BSparseMatrixCSC%7BTv%2C%20Ti%7D%2C%20SparseMatrixCSC%7BTv%2C%20Ti%7D%2C%20AbstractVector%7BTp%7D%2C%20AbstractVector%7BTq%7D%7D%7D%20where%20%7BTv%2C%20Ti%2C%20Tp%3C%3AInteger%2C%20Tq%3C%3AInteger%7D"
+[[jl.method]]
+name = "Base.pipeline-Tuple{Any, Any, Any, Vararg{Any}}"
+uri = "base/base/#Base.pipeline-Tuple%7BAny%2C%20Any%2C%20Any%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "Base.pipeline-Tuple{Base.AbstractCmd}"
+uri = "base/base/#Base.pipeline-Tuple%7BBase.AbstractCmd%7D"
+[[jl.method]]
+name = "Base.pkgdir-Tuple{Module}"
+uri = "base/base/#Base.pkgdir-Tuple%7BModule%7D"
+[[jl.method]]
+name = "Base.pkgversion-Tuple{Module}"
+uri = "base/base/#Base.pkgversion-Tuple%7BModule%7D"
+[[jl.method]]
+name = "Base.pop!-Tuple{Any, Any, Any}"
+uri = "base/collections/#Base.pop%21-Tuple%7BAny%2C%20Any%2C%20Any%7D"
+[[jl.method]]
+name = "Base.put!-Tuple{Channel, Any}"
+uri = "base/parallel/#Base.put%21-Tuple%7BChannel%2C%20Any%7D"
+[[jl.method]]
+name = "Base.put!-Tuple{Distributed.Future, Any}"
+uri = "stdlib/Distributed/#Base.put%21-Tuple%7BDistributed.Future%2C%20Any%7D"
+[[jl.method]]
+name = "Base.put!-Tuple{RemoteChannel, Vararg{Any}}"
+uri = "stdlib/Distributed/#Base.put%21-Tuple%7BRemoteChannel%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "Base.redirect_stderr-Tuple{Function, Any}"
+uri = "base/io-network/#Base.redirect_stderr-Tuple%7BFunction%2C%20Any%7D"
+[[jl.method]]
+name = "Base.redirect_stdin-Tuple{Function, Any}"
+uri = "base/io-network/#Base.redirect_stdin-Tuple%7BFunction%2C%20Any%7D"
+[[jl.method]]
+name = "Base.redirect_stdout-Tuple{Function, Any}"
+uri = "base/io-network/#Base.redirect_stdout-Tuple%7BFunction%2C%20Any%7D"
+[[jl.method]]
+name = "Base.reduce-Tuple{Any, AbstractArray}"
+uri = "base/collections/#Base.reduce-Tuple%7BAny%2C%20AbstractArray%7D"
+[[jl.method]]
+name = "Base.reduce-Tuple{Any, Any}"
+uri = "base/collections/#Base.reduce-Tuple%7BAny%2C%20Any%7D"
+[[jl.method]]
+name = "Base.repeat-Tuple{AbstractChar, Integer}"
+uri = "base/strings/#Base.repeat-Tuple%7BAbstractChar%2C%20Integer%7D"
+[[jl.method]]
+name = "Base.repeat-Tuple{AbstractString, Integer}"
+uri = "base/strings/#Base.repeat-Tuple%7BAbstractString%2C%20Integer%7D"
+[[jl.method]]
+name = "Base.replace-Tuple{Any, Vararg{Pair}}"
+uri = "base/collections/#Base.replace-Tuple%7BAny%2C%20Vararg%7BPair%7D%7D"
+[[jl.method]]
+name = "Base.replace-Tuple{IO, AbstractString, Vararg{Pair}}"
+uri = "base/strings/#Base.replace-Tuple%7BIO%2C%20AbstractString%2C%20Vararg%7BPair%7D%7D"
+[[jl.method]]
+name = "Base.replace-Tuple{Union{Function, Type}, Any}"
+uri = "base/collections/#Base.replace-Tuple%7BUnion%7BFunction%2C%20Type%7D%2C%20Any%7D"
+[[jl.method]]
+name = "Base.repr-Tuple{Any}"
+uri = "base/strings/#Base.repr-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Base.repr-Tuple{MIME, Any}"
+uri = "base/io-network/#Base.repr-Tuple%7BMIME%2C%20Any%7D"
+[[jl.method]]
+name = "Base.reset-Tuple{Base.Event}"
+uri = "base/parallel/#Base.reset-Tuple%7BBase.Event%7D"
+[[jl.method]]
+name = "Base.reset-Tuple{IO}"
+uri = "base/io-network/#Base.reset-Tuple%7BIO%7D"
+[[jl.method]]
+name = "Base.reverse-Tuple{AbstractVector}"
+uri = "base/arrays/#Base.reverse-Tuple%7BAbstractVector%7D"
+[[jl.method]]
+name = "Base.reverse-Tuple{Union{SubString{String}, String}}"
+uri = "base/strings/#Base.reverse-Tuple%7BUnion%7BSubString%7BString%7D%2C%20String%7D%7D"
+[[jl.method]]
+name = "Base.round-Tuple{Complex{<:AbstractFloat}, RoundingMode, RoundingMode}"
+uri = "base/math/#Base.round-Tuple%7BComplex%7B%3C%3AAbstractFloat%7D%2C%20RoundingMode%2C%20RoundingMode%7D"
+[[jl.method]]
+name = "Base.round-Tuple{TimeType, Period, RoundingMode{:NearestTiesUp}}"
+uri = "stdlib/Dates/#Base.round-Tuple%7BTimeType%2C%20Period%2C%20RoundingMode%7B%3ANearestTiesUp%7D%7D"
+[[jl.method]]
+name = "Base.round-Tuple{Type, Any}"
+uri = "base/math/#Base.round-Tuple%7BType%2C%20Any%7D"
+[[jl.method]]
+name = "Base.round-Tuple{Union{Day, Week, TimePeriod}, Union{Day, Week, TimePeriod}, RoundingMode{:NearestTiesUp}}"
+uri = "stdlib/Dates/#Base.round-Tuple%7BUnion%7BDay%2C%20Week%2C%20TimePeriod%7D%2C%20Union%7BDay%2C%20Week%2C%20TimePeriod%7D%2C%20RoundingMode%7B%3ANearestTiesUp%7D%7D"
+[[jl.method]]
+name = "Base.setindex!-Tuple{AbstractArray, Any, Vararg{Any}}"
+uri = "base/arrays/#Base.setindex%21-Tuple%7BAbstractArray%2C%20Any%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "Base.show-Tuple{IO, Any, Any}"
+uri = "base/io-network/#Base.show-Tuple%7BIO%2C%20Any%2C%20Any%7D"
+[[jl.method]]
+name = "Base.show-Tuple{IO, Any}"
+uri = "base/io-network/#Base.show-Tuple%7BIO%2C%20Any%7D"
+[[jl.method]]
+name = "Base.similar-Tuple{SparseArrays.AbstractSparseMatrixCSC, Type}"
+uri = "stdlib/SparseArrays/#Base.similar-Tuple%7BSparseArrays.AbstractSparseMatrixCSC%2C%20Type%7D"
+[[jl.method]]
+name = "Base.sin-Tuple{Number}"
+uri = "base/math/#Base.sin-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.sin-Tuple{StridedMatrix{var\"#s51\"} where var\"#s51\"<:Real}"
+uri = "stdlib/LinearAlgebra/#Base.sin-Tuple%7BStridedMatrix%7Bvar%22%23s51%22%7D%20where%20var%22%23s51%22%3C%3AReal%7D"
+[[jl.method]]
+name = "Base.sinh-Tuple{Number}"
+uri = "base/math/#Base.sinh-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.sinh-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.sinh-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.sizeof-Tuple{AbstractString}"
+uri = "base/strings/#Base.sizeof-Tuple%7BAbstractString%7D"
+[[jl.method]]
+name = "Base.sizeof-Tuple{Type}"
+uri = "base/base/#Base.sizeof-Tuple%7BType%7D"
+[[jl.method]]
+name = "Base.sqrt-Tuple{Number}"
+uri = "base/math/#Base.sqrt-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.sqrt-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.sqrt-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.take!-Tuple{Base.GenericIOBuffer}"
+uri = "base/io-network/#Base.take%21-Tuple%7BBase.GenericIOBuffer%7D"
+[[jl.method]]
+name = "Base.take!-Tuple{Channel}"
+uri = "base/parallel/#Base.take%21-Tuple%7BChannel%7D"
+[[jl.method]]
+name = "Base.take!-Tuple{RemoteChannel, Vararg{Any}}"
+uri = "stdlib/Distributed/#Base.take%21-Tuple%7BRemoteChannel%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "Base.tan-Tuple{Number}"
+uri = "base/math/#Base.tan-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.tan-Tuple{StridedMatrix{var\"#s51\"} where var\"#s51\"<:Real}"
+uri = "stdlib/LinearAlgebra/#Base.tan-Tuple%7BStridedMatrix%7Bvar%22%23s51%22%7D%20where%20var%22%23s51%22%3C%3AReal%7D"
+[[jl.method]]
+name = "Base.tanh-Tuple{Number}"
+uri = "base/math/#Base.tanh-Tuple%7BNumber%7D"
+[[jl.method]]
+name = "Base.tanh-Tuple{StridedMatrix{T} where T}"
+uri = "stdlib/LinearAlgebra/#Base.tanh-Tuple%7BStridedMatrix%7BT%7D%20where%20T%7D"
+[[jl.method]]
+name = "Base.task_local_storage-Tuple{Any, Any}"
+uri = "base/parallel/#Base.task_local_storage-Tuple%7BAny%2C%20Any%7D"
+[[jl.method]]
+name = "Base.task_local_storage-Tuple{Any}"
+uri = "base/parallel/#Base.task_local_storage-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Base.task_local_storage-Tuple{Function, Any, Any}"
+uri = "base/parallel/#Base.task_local_storage-Tuple%7BFunction%2C%20Any%2C%20Any%7D"
+[[jl.method]]
+name = "Base.trunc-Tuple{TimeType, Type{Period}}"
+uri = "stdlib/Dates/#Base.trunc-Tuple%7BTimeType%2C%20Type%7BPeriod%7D%7D"
+[[jl.method]]
+name = "Base.unsafe_copyto!-Union{Tuple{T}, Tuple{Array{T}, Any, Array{T}, Any, Any}} where T"
+uri = "base/c/#Base.unsafe_copyto%21-Union%7BTuple%7BT%7D%2C%20Tuple%7BArray%7BT%7D%2C%20Any%2C%20Array%7BT%7D%2C%20Any%2C%20Any%7D%7D%20where%20T"
+[[jl.method]]
+name = "Base.unsafe_copyto!-Union{Tuple{T}, Tuple{Ptr{T}, Ptr{T}, Any}} where T"
+uri = "base/c/#Base.unsafe_copyto%21-Union%7BTuple%7BT%7D%2C%20Tuple%7BPtr%7BT%7D%2C%20Ptr%7BT%7D%2C%20Any%7D%7D%20where%20T"
+[[jl.method]]
+name = "Base.unsafe_wrap-Union{Tuple{N}, Tuple{T}, Tuple{Union{Type{Array}, Type{Array{T}}, Type{Array{T, N}}}, Ptr{T}, Tuple{Vararg{Int64, N}}}} where {T, N}"
+uri = "base/c/#Base.unsafe_wrap-Union%7BTuple%7BN%7D%2C%20Tuple%7BT%7D%2C%20Tuple%7BUnion%7BType%7BArray%7D%2C%20Type%7BArray%7BT%7D%7D%2C%20Type%7BArray%7BT%2C%20N%7D%7D%7D%2C%20Ptr%7BT%7D%2C%20Tuple%7BVararg%7BInt64%2C%20N%7D%7D%7D%7D%20where%20%7BT%2C%20N%7D"
+[[jl.method]]
+name = "Base.which-Tuple{Any, Any}"
+uri = "base/base/#Base.which-Tuple%7BAny%2C%20Any%7D"
+[[jl.method]]
+name = "CRC32c.crc32c-Tuple{IO, Integer, UInt32}"
+uri = "stdlib/CRC32c/#CRC32c.crc32c-Tuple%7BIO%2C%20Integer%2C%20UInt32%7D"
+[[jl.method]]
+name = "Core.Array-Tuple{Missing, Any}"
+uri = "base/arrays/#Core.Array-Tuple%7BMissing%2C%20Any%7D"
+[[jl.method]]
+name = "Core.Array-Tuple{Nothing, Any}"
+uri = "base/arrays/#Core.Array-Tuple%7BNothing%2C%20Any%7D"
+[[jl.method]]
+name = "Core.Array-Tuple{UndefInitializer, Any}"
+uri = "base/arrays/#Core.Array-Tuple%7BUndefInitializer%2C%20Any%7D"
+[[jl.method]]
+name = "Core.Float32-Tuple{Any}"
+uri = "base/numbers/#Core.Float32-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Core.Float64-Tuple{Any}"
+uri = "base/numbers/#Core.Float64-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Core.String-Tuple{AbstractString}"
+uri = "base/strings/#Core.String-Tuple%7BAbstractString%7D"
+[[jl.method]]
+name = "Core.Symbol-Tuple"
+uri = "base/base/#$"
+[[jl.method]]
+name = "Dates.CompoundPeriod-Tuple{Vector{<:Period}}"
+uri = "stdlib/Dates/#Dates.CompoundPeriod-Tuple%7BVector%7B%3C%3APeriod%7D%7D"
+[[jl.method]]
+name = "Dates.Date-Tuple{AbstractString, AbstractString}"
+uri = "stdlib/Dates/#Dates.Date-Tuple%7BAbstractString%2C%20AbstractString%7D"
+[[jl.method]]
+name = "Dates.Date-Tuple{AbstractString, DateFormat}"
+uri = "stdlib/Dates/#Dates.Date-Tuple%7BAbstractString%2C%20DateFormat%7D"
+[[jl.method]]
+name = "Dates.Date-Tuple{Function, Any, Any, Any}"
+uri = "stdlib/Dates/#Dates.Date-Tuple%7BFunction%2C%20Any%2C%20Any%2C%20Any%7D"
+[[jl.method]]
+name = "Dates.Date-Tuple{Int64, Int64, Int64}"
+uri = "stdlib/Dates/#Dates.Date-Tuple%7BInt64%2C%20Int64%2C%20Int64%7D"
+[[jl.method]]
+name = "Dates.Date-Tuple{Period}"
+uri = "stdlib/Dates/#Dates.Date-Tuple%7BPeriod%7D"
+[[jl.method]]
+name = "Dates.Date-Tuple{TimeType}"
+uri = "stdlib/Dates/#Dates.Date-Tuple%7BTimeType%7D"
+[[jl.method]]
+name = "Dates.DateTime-NTuple{7, Int64}"
+uri = "stdlib/Dates/#Dates.DateTime-NTuple%7B7%2C%20Int64%7D"
+[[jl.method]]
+name = "Dates.DateTime-Tuple{AbstractString, AbstractString}"
+uri = "stdlib/Dates/#Dates.DateTime-Tuple%7BAbstractString%2C%20AbstractString%7D"
+[[jl.method]]
+name = "Dates.DateTime-Tuple{AbstractString, DateFormat}"
+uri = "stdlib/Dates/#Dates.DateTime-Tuple%7BAbstractString%2C%20DateFormat%7D"
+[[jl.method]]
+name = "Dates.DateTime-Tuple{Function, Vararg{Any}}"
+uri = "stdlib/Dates/#Dates.DateTime-Tuple%7BFunction%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "Dates.DateTime-Tuple{Period}"
+uri = "stdlib/Dates/#Dates.DateTime-Tuple%7BPeriod%7D"
+[[jl.method]]
+name = "Dates.DateTime-Tuple{TimeType}"
+uri = "stdlib/Dates/#Dates.DateTime-Tuple%7BTimeType%7D"
+[[jl.method]]
+name = "Dates.Day-Tuple{TimeType}"
+uri = "stdlib/Dates/#Dates.Day-Tuple%7BTimeType%7D"
+[[jl.method]]
+name = "Dates.Hour-Tuple{DateTime}"
+uri = "stdlib/Dates/#Dates.Hour-Tuple%7BDateTime%7D"
+[[jl.method]]
+name = "Dates.Microsecond-Tuple{Time}"
+uri = "stdlib/Dates/#Dates.Microsecond-Tuple%7BTime%7D"
+[[jl.method]]
+name = "Dates.Millisecond-Tuple{DateTime}"
+uri = "stdlib/Dates/#Dates.Millisecond-Tuple%7BDateTime%7D"
+[[jl.method]]
+name = "Dates.Minute-Tuple{DateTime}"
+uri = "stdlib/Dates/#Dates.Minute-Tuple%7BDateTime%7D"
+[[jl.method]]
+name = "Dates.Month-Tuple{TimeType}"
+uri = "stdlib/Dates/#Dates.Month-Tuple%7BTimeType%7D"
+[[jl.method]]
+name = "Dates.Nanosecond-Tuple{Time}"
+uri = "stdlib/Dates/#Dates.Nanosecond-Tuple%7BTime%7D"
+[[jl.method]]
+name = "Dates.Period-Tuple{Any}"
+uri = "stdlib/Dates/#Dates.Period-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Dates.Second-Tuple{DateTime}"
+uri = "stdlib/Dates/#Dates.Second-Tuple%7BDateTime%7D"
+[[jl.method]]
+name = "Dates.Time-NTuple{5, Int64}"
+uri = "stdlib/Dates/#Dates.Time-NTuple%7B5%2C%20Int64%7D"
+[[jl.method]]
+name = "Dates.Time-Tuple{AbstractString, AbstractString}"
+uri = "stdlib/Dates/#Dates.Time-Tuple%7BAbstractString%2C%20AbstractString%7D"
+[[jl.method]]
+name = "Dates.Time-Tuple{AbstractString, DateFormat}"
+uri = "stdlib/Dates/#Dates.Time-Tuple%7BAbstractString%2C%20DateFormat%7D"
+[[jl.method]]
+name = "Dates.Time-Tuple{DateTime}"
+uri = "stdlib/Dates/#Dates.Time-Tuple%7BDateTime%7D"
+[[jl.method]]
+name = "Dates.Time-Tuple{Function, Vararg{Any}}"
+uri = "stdlib/Dates/#Dates.Time-Tuple%7BFunction%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "Dates.Time-Tuple{TimePeriod}"
+uri = "stdlib/Dates/#Dates.Time-Tuple%7BTimePeriod%7D"
+[[jl.method]]
+name = "Dates.Week-Tuple{TimeType}"
+uri = "stdlib/Dates/#Dates.Week-Tuple%7BTimeType%7D"
+[[jl.method]]
+name = "Dates.Year-Tuple{TimeType}"
+uri = "stdlib/Dates/#Dates.Year-Tuple%7BTimeType%7D"
+[[jl.method]]
+name = "Dates.format-Tuple{TimeType, AbstractString}"
+uri = "stdlib/Dates/#Dates.format-Tuple%7BTimeType%2C%20AbstractString%7D"
+[[jl.method]]
+name = "Dates.now-Tuple{Type{UTC}}"
+uri = "stdlib/Dates/#Dates.now-Tuple%7BType%7BUTC%7D%7D"
+[[jl.method]]
+name = "Dates.now-Tuple{}"
+uri = "stdlib/Dates/#Dates.now-Tuple%7B%7D"
+[[jl.method]]
+name = "Dates.tonext-Tuple{Function, TimeType}"
+uri = "stdlib/Dates/#Dates.tonext-Tuple%7BFunction%2C%20TimeType%7D"
+[[jl.method]]
+name = "Dates.tonext-Tuple{TimeType, Int64}"
+uri = "stdlib/Dates/#Dates.tonext-Tuple%7BTimeType%2C%20Int64%7D"
+[[jl.method]]
+name = "Dates.toprev-Tuple{Function, TimeType}"
+uri = "stdlib/Dates/#Dates.toprev-Tuple%7BFunction%2C%20TimeType%7D"
+[[jl.method]]
+name = "Dates.toprev-Tuple{TimeType, Int64}"
+uri = "stdlib/Dates/#Dates.toprev-Tuple%7BTimeType%2C%20Int64%7D"
+[[jl.method]]
+name = "DelimitedFiles.readdlm-Tuple{Any, AbstractChar, AbstractChar}"
+uri = "stdlib/DelimitedFiles/#DelimitedFiles.readdlm-Tuple%7BAny%2C%20AbstractChar%2C%20AbstractChar%7D"
+[[jl.method]]
+name = "DelimitedFiles.readdlm-Tuple{Any, AbstractChar, Type, AbstractChar}"
+uri = "stdlib/DelimitedFiles/#DelimitedFiles.readdlm-Tuple%7BAny%2C%20AbstractChar%2C%20Type%2C%20AbstractChar%7D"
+[[jl.method]]
+name = "DelimitedFiles.readdlm-Tuple{Any, AbstractChar, Type}"
+uri = "stdlib/DelimitedFiles/#DelimitedFiles.readdlm-Tuple%7BAny%2C%20AbstractChar%2C%20Type%7D"
+[[jl.method]]
+name = "DelimitedFiles.readdlm-Tuple{Any, AbstractChar}"
+uri = "stdlib/DelimitedFiles/#DelimitedFiles.readdlm-Tuple%7BAny%2C%20AbstractChar%7D"
+[[jl.method]]
+name = "DelimitedFiles.readdlm-Tuple{Any, Type}"
+uri = "stdlib/DelimitedFiles/#DelimitedFiles.readdlm-Tuple%7BAny%2C%20Type%7D"
+[[jl.method]]
+name = "DelimitedFiles.readdlm-Tuple{Any}"
+uri = "stdlib/DelimitedFiles/#DelimitedFiles.readdlm-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Distributed.clear!-Tuple{Any, Any}"
+uri = "stdlib/Distributed/#Distributed.clear%21-Tuple%7BAny%2C%20Any%7D"
+[[jl.method]]
+name = "Distributed.clear!-Tuple{CachingPool}"
+uri = "stdlib/Distributed/#Distributed.clear%21-Tuple%7BCachingPool%7D"
+[[jl.method]]
+name = "Distributed.cluster_cookie-Tuple{Any}"
+uri = "stdlib/Distributed/#Distributed.cluster_cookie-Tuple%7BAny%7D"
+[[jl.method]]
+name = "Distributed.cluster_cookie-Tuple{}"
+uri = "stdlib/Distributed/#Distributed.cluster_cookie-Tuple%7B%7D"
+[[jl.method]]
+name = "Distributed.procs-Tuple{Integer}"
+uri = "stdlib/Distributed/#Distributed.procs-Tuple%7BInteger%7D"
+[[jl.method]]
+name = "Distributed.procs-Tuple{SharedArray}"
+uri = "stdlib/SharedArrays/#Distributed.procs-Tuple%7BSharedArray%7D"
+[[jl.method]]
+name = "Distributed.procs-Tuple{}"
+uri = "stdlib/Distributed/#Distributed.procs-Tuple%7B%7D"
+[[jl.method]]
+name = "Distributed.remote_do-Tuple{Any, AbstractWorkerPool, Vararg{Any}}"
+uri = "stdlib/Distributed/#Distributed.remote_do-Tuple%7BAny%2C%20AbstractWorkerPool%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "Distributed.remote_do-Tuple{Any, Integer, Vararg{Any}}"
+uri = "stdlib/Distributed/#Distributed.remote_do-Tuple%7BAny%2C%20Integer%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "Distributed.remotecall-Tuple{Any, AbstractWorkerPool, Vararg{Any}}"
+uri = "stdlib/Distributed/#Distributed.remotecall-Tuple%7BAny%2C%20AbstractWorkerPool%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "Distributed.remotecall-Tuple{Any, Integer, Vararg{Any}}"
+uri = "stdlib/Distributed/#Distributed.remotecall-Tuple%7BAny%2C%20Integer%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "Distributed.remotecall_fetch-Tuple{Any, AbstractWorkerPool, Vararg{Any}}"
+uri = "stdlib/Distributed/#Distributed.remotecall_fetch-Tuple%7BAny%2C%20AbstractWorkerPool%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "Distributed.remotecall_fetch-Tuple{Any, Integer, Vararg{Any}}"
+uri = "stdlib/Distributed/#Distributed.remotecall_fetch-Tuple%7BAny%2C%20Integer%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "Distributed.remotecall_wait-Tuple{Any, AbstractWorkerPool, Vararg{Any}}"
+uri = "stdlib/Distributed/#Distributed.remotecall_wait-Tuple%7BAny%2C%20AbstractWorkerPool%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "Distributed.remotecall_wait-Tuple{Any, Integer, Vararg{Any}}"
+uri = "stdlib/Distributed/#Distributed.remotecall_wait-Tuple%7BAny%2C%20Integer%2C%20Vararg%7BAny%7D%7D"
+[[jl.method]]
+name = "InteractiveUtils.edit-Tuple{AbstractString, Integer}"
+uri = "stdlib/InteractiveUtils/#InteractiveUtils.edit-Tuple%7BAbstractString%2C%20Integer%7D"
+[[jl.method]]
+name = "InteractiveUtils.edit-Tuple{Any}"
+uri = "stdlib/InteractiveUtils/#InteractiveUtils.edit-Tuple%7BAny%7D"
+[[jl.method]]
+name = "InteractiveUtils.less-Tuple{AbstractString}"
+uri = "stdlib/InteractiveUtils/#InteractiveUtils.less-Tuple%7BAbstractString%7D"
+[[jl.method]]
+name = "InteractiveUtils.less-Tuple{Any}"
+uri = "stdlib/InteractiveUtils/#InteractiveUtils.less-Tuple%7BAny%7D"
+[[jl.method]]
+name = "LibGit2.GitObject-Tuple{LibGit2.GitTreeEntry}"
+uri = "stdlib/LibGit2/#LibGit2.GitObject-Tuple%7BLibGit2.GitTreeEntry%7D"
+[[jl.method]]
+name = "LibGit2.merge!-Tuple{GitRepo, Vector{LibGit2.GitAnnotated}, Bool}"
+uri = "stdlib/LibGit2/#LibGit2.merge%21-Tuple%7BGitRepo%2C%20Vector%7BLibGit2.GitAnnotated%7D%2C%20Bool%7D"
+[[jl.method]]
+name = "LibGit2.merge!-Tuple{GitRepo, Vector{LibGit2.GitAnnotated}}"
+uri = "stdlib/LibGit2/#LibGit2.merge%21-Tuple%7BGitRepo%2C%20Vector%7BLibGit2.GitAnnotated%7D%7D"
+[[jl.method]]
+name = "LibGit2.merge!-Tuple{GitRepo}"
+uri = "stdlib/LibGit2/#LibGit2.merge%21-Tuple%7BGitRepo%7D"
+[[jl.method]]
+name = "LibGit2.push!-Tuple{LibGit2.GitRevWalker, LibGit2.GitHash}"
+uri = "stdlib/LibGit2/#LibGit2.push%21-Tuple%7BLibGit2.GitRevWalker%2C%20LibGit2.GitHash%7D"
+[[jl.method]]
+name = "LinearAlgebra.BLAS.gemm-NTuple{4, Any}"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.gemm-NTuple%7B4%2C%20Any%7D"
+[[jl.method]]
+name = "LinearAlgebra.BLAS.gemm-NTuple{5, Any}"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.gemm-NTuple%7B5%2C%20Any%7D"
+[[jl.method]]
+name = "LinearAlgebra.BLAS.gemv-NTuple{4, Any}"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.gemv-NTuple%7B4%2C%20Any%7D"
+[[jl.method]]
+name = "LinearAlgebra.BLAS.gemv-Tuple{Any, Any, Any}"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.gemv-Tuple%7BAny%2C%20Any%2C%20Any%7D"
+[[jl.method]]
+name = "LinearAlgebra.BLAS.hemm-NTuple{4, Any}"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.hemm-NTuple%7B4%2C%20Any%7D"
+[[jl.method]]
+name = "LinearAlgebra.BLAS.hemm-NTuple{5, Any}"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.hemm-NTuple%7B5%2C%20Any%7D"
+[[jl.method]]
+name = "LinearAlgebra.BLAS.hemv-NTuple{4, Any}"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.hemv-NTuple%7B4%2C%20Any%7D"
+[[jl.method]]
+name = "LinearAlgebra.BLAS.hemv-Tuple{Any, Any, Any}"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.hemv-Tuple%7BAny%2C%20Any%2C%20Any%7D"
+[[jl.method]]
+name = "LinearAlgebra.BLAS.sbmv-NTuple{4, Any}"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.sbmv-NTuple%7B4%2C%20Any%7D"
+[[jl.method]]
+name = "LinearAlgebra.BLAS.sbmv-NTuple{5, Any}"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.sbmv-NTuple%7B5%2C%20Any%7D"
+[[jl.method]]
+name = "LinearAlgebra.BLAS.symm-NTuple{4, Any}"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.symm-NTuple%7B4%2C%20Any%7D"
+[[jl.method]]
+name = "LinearAlgebra.BLAS.symm-NTuple{5, Any}"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.symm-NTuple%7B5%2C%20Any%7D"
+[[jl.method]]
+name = "LinearAlgebra.BLAS.symv-NTuple{4, Any}"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.symv-NTuple%7B4%2C%20Any%7D"
+[[jl.method]]
+name = "LinearAlgebra.BLAS.symv-Tuple{Any, Any, Any}"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.BLAS.symv-Tuple%7BAny%2C%20Any%2C%20Any%7D"
+[[jl.method]]
+name = "LinearAlgebra.UniformScaling-Tuple{Integer}"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.UniformScaling-Tuple%7BInteger%7D"
+[[jl.method]]
+name = "LinearAlgebra.dot-Tuple{Any, Any, Any}"
+uri = "stdlib/LinearAlgebra/#LinearAlgebra.dot-Tuple%7BAny%2C%20Any%2C%20Any%7D"
+[[jl.method]]
+name = "Sockets.connect-Tuple{AbstractString}"
+uri = "stdlib/Sockets/#Sockets.connect-Tuple%7BAbstractString%7D"
+[[jl.method]]
+name = "Sockets.connect-Tuple{ClusterManager, Int64, WorkerConfig}"
+uri = "stdlib/Distributed/#Sockets.connect-Tuple%7BClusterManager%2C%20Int64%2C%20WorkerConfig%7D"
+[[jl.method]]
+name = "Sockets.connect-Tuple{TCPSocket, Integer}"
+uri = "stdlib/Sockets/#Sockets.connect-Tuple%7BTCPSocket%2C%20Integer%7D"
+[[jl.method]]
+name = "Sockets.listen-Tuple{AbstractString}"
+uri = "stdlib/Sockets/#Sockets.listen-Tuple%7BAbstractString%7D"
+[[jl.method]]
+name = "Sockets.listen-Tuple{Any}"
+uri = "stdlib/Sockets/#Sockets.listen-Tuple%7BAny%7D"
+
+[[jl.module]]
+name = "Base"
+uri = "base/base/#$"
+[[jl.module]]
+name = "Base.Broadcast"
+uri = "base/base/#$"
+[[jl.module]]
+name = "Base.Docs"
+uri = "base/base/#$"
+[[jl.module]]
+name = "Base.GC"
+uri = "base/base/#$"
+[[jl.module]]
+name = "Base.Iterators"
+uri = "base/base/#$"
+[[jl.module]]
+name = "Base.Libc"
+uri = "base/base/#$"
+[[jl.module]]
+name = "Base.Meta"
+uri = "base/base/#$"
+[[jl.module]]
+name = "Base.StackTraces"
+uri = "base/base/#$"
+[[jl.module]]
+name = "Base.Sys"
+uri = "base/base/#$"
+[[jl.module]]
+name = "Base.Threads"
+uri = "base/base/#$"
+[[jl.module]]
+name = "Base64.Base64"
+uri = "stdlib/Base64/#$"
+[[jl.module]]
+name = "Core"
+uri = "base/base/#$"
+[[jl.module]]
+name = "LinearAlgebra.BLAS"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.module]]
+name = "LinearAlgebra.LAPACK"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.module]]
+name = "Logging.Logging"
+uri = "stdlib/Logging/#$"
+[[jl.module]]
+name = "Main"
+uri = "base/base/#$"
+[[jl.module]]
+name = "Random.Random"
+uri = "stdlib/Random/#$"
+[[jl.module]]
+name = "Sockets.Sockets"
+uri = "stdlib/Sockets/#$"
+
+[[jl.type]]
+name = "ArgTools.ArgRead"
+uri = "stdlib/ArgTools/#$"
+[[jl.type]]
+name = "ArgTools.ArgWrite"
+uri = "stdlib/ArgTools/#$"
+[[jl.type]]
+name = "Base.AbstractChannel"
+uri = "base/parallel/#$"
+[[jl.type]]
+name = "Base.AbstractDict"
+uri = "base/collections/#$"
+[[jl.type]]
+name = "Base.AbstractIrrational"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Base.AbstractLock"
+uri = "base/parallel/#$"
+[[jl.type]]
+name = "Base.AbstractMatrix"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.AbstractRange"
+uri = "base/collections/#$"
+[[jl.type]]
+name = "Base.AbstractSet"
+uri = "base/collections/#$"
+[[jl.type]]
+name = "Base.AbstractUnitRange"
+uri = "base/collections/#$"
+[[jl.type]]
+name = "Base.AbstractVecOrMat"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.AbstractVector"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.AsyncCondition"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.BitArray"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.BitSet"
+uri = "base/collections/#$"
+[[jl.type]]
+name = "Base.Broadcast.AbstractArrayStyle"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.Broadcast.ArrayStyle"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.Broadcast.BroadcastStyle"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.Broadcast.DefaultArrayStyle"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.CFunction"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Cchar"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Cdouble"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Cfloat"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Channel"
+uri = "base/parallel/#$"
+[[jl.type]]
+name = "Base.Cint"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Cintmax_t"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Clong"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Clonglong"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Cmd"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.Colon"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.ColumnSlices"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.Complex"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Base.ComposedFunction"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.CompositeException"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.Condition"
+uri = "base/parallel/#$"
+[[jl.type]]
+name = "Base.Cptrdiff_t"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Cshort"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Csize_t"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Cssize_t"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Cstring"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Cuchar"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Cuint"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Cuintmax_t"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Culong"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Culonglong"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Cushort"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Cwchar_t"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.Cwstring"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Base.DenseMatrix"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.DenseVecOrMat"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.DenseVector"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.Dict"
+uri = "base/collections/#$"
+[[jl.type]]
+name = "Base.DimensionMismatch"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.Dims"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.EOFError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.Enums.Enum"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.EnvDict"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.Event"
+uri = "base/parallel/#$"
+[[jl.type]]
+name = "Base.ExponentialBackOff"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.Fix1"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.Fix2"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.GMP.BigInt"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Base.IOBuffer"
+uri = "base/io-network/#$"
+[[jl.type]]
+name = "Base.IOContext"
+uri = "base/io-network/#$"
+[[jl.type]]
+name = "Base.IOStream"
+uri = "base/io-network/#$"
+[[jl.type]]
+name = "Base.IdDict"
+uri = "base/collections/#$"
+[[jl.type]]
+name = "Base.ImmutableDict"
+uri = "base/collections/#$"
+[[jl.type]]
+name = "Base.IndexCartesian"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.IndexLinear"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.IndexStyle"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.Irrational"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Base.IteratorEltype"
+uri = "base/collections/#$"
+[[jl.type]]
+name = "Base.IteratorSize"
+uri = "base/collections/#$"
+[[jl.type]]
+name = "Base.Iterators.Stateful"
+uri = "base/iterators/#$"
+[[jl.type]]
+name = "Base.IteratorsMD.CartesianIndex"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.IteratorsMD.CartesianIndices"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.KeyError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.LazyString"
+uri = "base/strings/#$"
+[[jl.type]]
+name = "Base.Libc.RawFD"
+uri = "base/file/#$"
+[[jl.type]]
+name = "Base.Libc.TmStruct"
+uri = "base/libc/#$"
+[[jl.type]]
+name = "Base.LinRange"
+uri = "base/collections/#$"
+[[jl.type]]
+name = "Base.LinearIndices"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.MPFR.BigFloat"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Base.Matrix"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.Meta.ParseError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.Missing"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.MissingException"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.Multimedia.AbstractDisplay"
+uri = "base/io-network/#$"
+[[jl.type]]
+name = "Base.Multimedia.MIME"
+uri = "base/io-network/#$"
+[[jl.type]]
+name = "Base.Multimedia.TextDisplay"
+uri = "base/io-network/#$"
+[[jl.type]]
+name = "Base.OneTo"
+uri = "base/math/#$"
+[[jl.type]]
+name = "Base.Order.By"
+uri = "base/sort/#$"
+[[jl.type]]
+name = "Base.Order.Lt"
+uri = "base/sort/#$"
+[[jl.type]]
+name = "Base.Order.Ordering"
+uri = "base/sort/#$"
+[[jl.type]]
+name = "Base.Order.Perm"
+uri = "base/sort/#$"
+[[jl.type]]
+name = "Base.Order.ReverseOrdering"
+uri = "base/sort/#$"
+[[jl.type]]
+name = "Base.OrdinalRange"
+uri = "base/collections/#$"
+[[jl.type]]
+name = "Base.Pairs"
+uri = "base/collections/#$"
+[[jl.type]]
+name = "Base.PermutedDimsArrays.PermutedDimsArray"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.ProcessFailedException"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.Rational"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Base.ReentrantLock"
+uri = "base/parallel/#$"
+[[jl.type]]
+name = "Base.Regex"
+uri = "base/strings/#$"
+[[jl.type]]
+name = "Base.RegexMatch"
+uri = "base/strings/#$"
+[[jl.type]]
+name = "Base.Rounding.RoundingMode"
+uri = "base/math/#$"
+[[jl.type]]
+name = "Base.RowSlices"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.Semaphore"
+uri = "base/parallel/#$"
+[[jl.type]]
+name = "Base.Set"
+uri = "base/collections/#$"
+[[jl.type]]
+name = "Base.Slices"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.Some"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.Sort.PartialQuickSort"
+uri = "base/sort/#$"
+[[jl.type]]
+name = "Base.StackTraces.StackFrame"
+uri = "base/stacktraces/#$"
+[[jl.type]]
+name = "Base.StackTraces.StackTrace"
+uri = "base/stacktraces/#$"
+[[jl.type]]
+name = "Base.StepRange"
+uri = "base/collections/#$"
+[[jl.type]]
+name = "Base.StepRangeLen"
+uri = "base/math/#$"
+[[jl.type]]
+name = "Base.StridedArray"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.StridedMatrix"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.StridedVecOrMat"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.StridedVector"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.StringIndexError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.SubArray"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.SubString"
+uri = "base/strings/#$"
+[[jl.type]]
+name = "Base.SubstitutionString"
+uri = "base/strings/#$"
+[[jl.type]]
+name = "Base.SystemError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.TaskFailedException"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.Threads.Atomic"
+uri = "base/multi-threading/#$"
+[[jl.type]]
+name = "Base.Threads.Condition"
+uri = "base/parallel/#$"
+[[jl.type]]
+name = "Base.Threads.SpinLock"
+uri = "base/multi-threading/#$"
+[[jl.type]]
+name = "Base.Timer"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.UnitRange"
+uri = "base/collections/#$"
+[[jl.type]]
+name = "Base.Val"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.VecOrMat"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.Vector"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Base.VersionNumber"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Base.WeakKeyDict"
+uri = "base/collections/#$"
+[[jl.type]]
+name = "Base64.Base64DecodePipe"
+uri = "stdlib/Base64/#$"
+[[jl.type]]
+name = "Base64.Base64EncodePipe"
+uri = "stdlib/Base64/#$"
+[[jl.type]]
+name = "Core.AbstractArray"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Core.AbstractChar"
+uri = "base/strings/#$"
+[[jl.type]]
+name = "Core.AbstractFloat"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.AbstractString"
+uri = "base/strings/#$"
+[[jl.type]]
+name = "Core.Any"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.ArgumentError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.Array"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Core.AssertionError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.Bool"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.BoundsError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.Char"
+uri = "base/strings/#$"
+[[jl.type]]
+name = "Core.Compiler.EscapeAnalysis.EscapeInfo"
+uri = "devdocs/EscapeAnalysis/#$"
+[[jl.type]]
+name = "Core.Compiler.EscapeAnalysis.EscapeState"
+uri = "devdocs/EscapeAnalysis/#$"
+[[jl.type]]
+name = "Core.DataType"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.DenseArray"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Core.DivideError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.DomainError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.ErrorException"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.Expr"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.Float16"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.Float32"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.Float64"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.Function"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.InexactError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.InitError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.Int128"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.Int16"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.Int32"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.Int64"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.Int8"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.Integer"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.InterruptException"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.LoadError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.MethodError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.Module"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.NTuple"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.NamedTuple"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.Nothing"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.Number"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.OutOfMemoryError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.OverflowError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.Pair"
+uri = "base/collections/#$"
+[[jl.type]]
+name = "Core.Ptr"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Core.QuoteNode"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.ReadOnlyMemoryError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.Real"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.Ref"
+uri = "base/c/#$"
+[[jl.type]]
+name = "Core.Signed"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.StackOverflowError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.Symbol"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.Task"
+uri = "base/parallel/#$"
+[[jl.type]]
+name = "Core.Tuple"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.Type"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.TypeError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.UInt128"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.UInt16"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.UInt32"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.UInt64"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.UInt8"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.UndefInitializer"
+uri = "base/arrays/#$"
+[[jl.type]]
+name = "Core.UndefKeywordError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.UndefRefError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.UndefVarError"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.Union"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.UnionAll"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Core.Unsigned"
+uri = "base/numbers/#$"
+[[jl.type]]
+name = "Core.WeakRef"
+uri = "base/base/#$"
+[[jl.type]]
+name = "Dates.CompoundPeriod"
+uri = "stdlib/Dates/#$"
+[[jl.type]]
+name = "Dates.Date"
+uri = "stdlib/Dates/#$"
+[[jl.type]]
+name = "Dates.DateFormat"
+uri = "stdlib/Dates/#$"
+[[jl.type]]
+name = "Dates.DateTime"
+uri = "stdlib/Dates/#$"
+[[jl.type]]
+name = "Dates.Instant"
+uri = "stdlib/Dates/#$"
+[[jl.type]]
+name = "Dates.Period"
+uri = "stdlib/Dates/#$"
+[[jl.type]]
+name = "Dates.Time"
+uri = "stdlib/Dates/#$"
+[[jl.type]]
+name = "Dates.TimeType"
+uri = "stdlib/Dates/#$"
+[[jl.type]]
+name = "Dates.TimeZone"
+uri = "stdlib/Dates/#$"
+[[jl.type]]
+name = "Dates.UTC"
+uri = "stdlib/Dates/#$"
+[[jl.type]]
+name = "Dates.UTInstant"
+uri = "stdlib/Dates/#$"
+[[jl.type]]
+name = "Distributed.AbstractWorkerPool"
+uri = "stdlib/Distributed/#$"
+[[jl.type]]
+name = "Distributed.CachingPool"
+uri = "stdlib/Distributed/#$"
+[[jl.type]]
+name = "Distributed.ClusterManager"
+uri = "stdlib/Distributed/#$"
+[[jl.type]]
+name = "Distributed.Future"
+uri = "stdlib/Distributed/#$"
+[[jl.type]]
+name = "Distributed.ProcessExitedException"
+uri = "stdlib/Distributed/#$"
+[[jl.type]]
+name = "Distributed.RemoteChannel"
+uri = "stdlib/Distributed/#$"
+[[jl.type]]
+name = "Distributed.RemoteException"
+uri = "stdlib/Distributed/#$"
+[[jl.type]]
+name = "Distributed.WorkerConfig"
+uri = "stdlib/Distributed/#$"
+[[jl.type]]
+name = "Distributed.WorkerPool"
+uri = "stdlib/Distributed/#$"
+[[jl.type]]
+name = "Downloads.Downloader"
+uri = "stdlib/Downloads/#$"
+[[jl.type]]
+name = "Downloads.RequestError"
+uri = "stdlib/Downloads/#$"
+[[jl.type]]
+name = "Downloads.Response"
+uri = "stdlib/Downloads/#$"
+[[jl.type]]
+name = "LibGit2.BlameOptions"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.Buffer"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.CachedCredentials"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.CheckoutOptions"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.CloneOptions"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.Consts.GIT_CONFIG"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.CredentialPayload"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.DescribeFormatOptions"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.DescribeOptions"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.DiffDelta"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.DiffFile"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.DiffOptionsStruct"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.FetchHead"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.FetchOptions"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.GitAnnotated"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.GitBlame"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.GitBlob"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.GitCommit"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.GitConfig"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.GitHash"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.GitObject"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.GitRemote"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.GitRepo"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.GitRevWalker"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.GitShortHash"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.GitSignature"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.GitStatus"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.GitTag"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.GitTree"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.IndexEntry"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.IndexTime"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.MergeOptions"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.ProxyOptions"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.PushOptions"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.RebaseOperation"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.RebaseOptions"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.RemoteCallbacks"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.SSHCredential"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.SignatureStruct"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.StatusEntry"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.StatusOptions"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.StrArrayStruct"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.TimeStruct"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LibGit2.UserPasswordCredential"
+uri = "stdlib/LibGit2/#$"
+[[jl.type]]
+name = "LinearAlgebra.Adjoint"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.AdjointFactorization"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.Bidiagonal"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.BunchKaufman"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.Cholesky"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.CholeskyPivoted"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.Diagonal"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.Eigen"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.Factorization"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.GeneralizedEigen"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.GeneralizedSVD"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.GeneralizedSchur"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.Givens"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.Hermitian"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.Hessenberg"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.LDLt"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.LQ"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.LU"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.LowerTriangular"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.PosDefException"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.QR"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.QRCompactWY"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.QRPivoted"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.SVD"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.Schur"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.SingularException"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.SymTridiagonal"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.Symmetric"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.Transpose"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.TransposeFactorization"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.Tridiagonal"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.UniformScaling"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.UnitLowerTriangular"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.UnitUpperTriangular"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.UpperHessenberg"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.UpperTriangular"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "LinearAlgebra.ZeroPivotException"
+uri = "stdlib/LinearAlgebra/#$"
+[[jl.type]]
+name = "Logging.AbstractLogger"
+uri = "stdlib/Logging/#$"
+[[jl.type]]
+name = "Logging.ConsoleLogger"
+uri = "stdlib/Logging/#$"
+[[jl.type]]
+name = "Logging.LogLevel"
+uri = "stdlib/Logging/#$"
+[[jl.type]]
+name = "Logging.NullLogger"
+uri = "stdlib/Logging/#$"
+[[jl.type]]
+name = "Logging.SimpleLogger"
+uri = "stdlib/Logging/#$"
+[[jl.type]]
+name = "Mmap.Anonymous"
+uri = "stdlib/Mmap/#$"
+[[jl.type]]
+name = "REPL.TerminalMenus.Config"
+uri = "stdlib/REPL/#$"
+[[jl.type]]
+name = "REPL.TerminalMenus.MultiSelectConfig"
+uri = "stdlib/REPL/#$"
+[[jl.type]]
+name = "REPL.TerminalMenus.MultiSelectMenu"
+uri = "stdlib/REPL/#$"
+[[jl.type]]
+name = "REPL.TerminalMenus.RadioMenu"
+uri = "stdlib/REPL/#$"
+[[jl.type]]
+name = "Random.AbstractRNG"
+uri = "stdlib/Random/#$"
+[[jl.type]]
+name = "Random.MersenneTwister"
+uri = "stdlib/Random/#$"
+[[jl.type]]
+name = "Random.RandomDevice"
+uri = "stdlib/Random/#$"
+[[jl.type]]
+name = "Random.Sampler"
+uri = "stdlib/Random/#$"
+[[jl.type]]
+name = "Random.SamplerSimple"
+uri = "stdlib/Random/#$"
+[[jl.type]]
+name = "Random.SamplerTrivial"
+uri = "stdlib/Random/#$"
+[[jl.type]]
+name = "Random.SamplerType"
+uri = "stdlib/Random/#$"
+[[jl.type]]
+name = "Random.TaskLocalRNG"
+uri = "stdlib/Random/#$"
+[[jl.type]]
+name = "Random.Xoshiro"
+uri = "stdlib/Random/#$"
+[[jl.type]]
+name = "SHA.HMAC_CTX"
+uri = "stdlib/SHA/#$"
+[[jl.type]]
+name = "SHA.SHA1_CTX"
+uri = "stdlib/SHA/#$"
+[[jl.type]]
+name = "SHA.SHA224_CTX"
+uri = "stdlib/SHA/#$"
+[[jl.type]]
+name = "SHA.SHA256_CTX"
+uri = "stdlib/SHA/#$"
+[[jl.type]]
+name = "SHA.SHA2_224_CTX"
+uri = "stdlib/SHA/#$"
+[[jl.type]]
+name = "SHA.SHA2_256_CTX"
+uri = "stdlib/SHA/#$"
+[[jl.type]]
+name = "SHA.SHA2_384_CTX"
+uri = "stdlib/SHA/#$"
+[[jl.type]]
+name = "SHA.SHA2_512_CTX"
+uri = "stdlib/SHA/#$"
+[[jl.type]]
+name = "SHA.SHA384_CTX"
+uri = "stdlib/SHA/#$"
+[[jl.type]]
+name = "SHA.SHA3_224_CTX"
+uri = "stdlib/SHA/#$"
+[[jl.type]]
+name = "SHA.SHA3_256_CTX"
+uri = "stdlib/SHA/#$"
+[[jl.type]]
+name = "SHA.SHA3_384_CTX"
+uri = "stdlib/SHA/#$"
+[[jl.type]]
+name = "SHA.SHA3_512_CTX"
+uri = "stdlib/SHA/#$"
+[[jl.type]]
+name = "SHA.SHA512_CTX"
+uri = "stdlib/SHA/#$"
+[[jl.type]]
+name = "SharedArrays.SharedArray"
+uri = "stdlib/SharedArrays/#$"
+[[jl.type]]
+name = "SharedArrays.SharedMatrix"
+uri = "stdlib/SharedArrays/#$"
+[[jl.type]]
+name = "SharedArrays.SharedVector"
+uri = "stdlib/SharedArrays/#$"
+[[jl.type]]
+name = "Sockets.DNSError"
+uri = "stdlib/Sockets/#$"
+[[jl.type]]
+name = "Sockets.IPAddr"
+uri = "stdlib/Sockets/#$"
+[[jl.type]]
+name = "Sockets.IPv4"
+uri = "stdlib/Sockets/#$"
+[[jl.type]]
+name = "Sockets.IPv6"
+uri = "stdlib/Sockets/#$"
+[[jl.type]]
+name = "Sockets.TCPSocket"
+uri = "stdlib/Sockets/#$"
+[[jl.type]]
+name = "Sockets.UDPSocket"
+uri = "stdlib/Sockets/#$"
+[[jl.type]]
+name = "SparseArrays.AbstractSparseArray"
+uri = "stdlib/SparseArrays/#$"
+[[jl.type]]
+name = "SparseArrays.AbstractSparseMatrix"
+uri = "stdlib/SparseArrays/#$"
+[[jl.type]]
+name = "SparseArrays.AbstractSparseVector"
+uri = "stdlib/SparseArrays/#$"
+[[jl.type]]
+name = "SparseArrays.SparseMatrixCSC"
+uri = "stdlib/SparseArrays/#$"
+[[jl.type]]
+name = "SparseArrays.SparseVector"
+uri = "stdlib/SparseArrays/#$"
+[[jl.type]]
+name = "TOML.Parser"
+uri = "stdlib/TOML/#$"
+[[jl.type]]
+name = "TOML.ParserError"
+uri = "stdlib/TOML/#$"
+[[jl.type]]
+name = "Tar.Header"
+uri = "stdlib/Tar/#$"
+[[jl.type]]
+name = "Test.Broken"
+uri = "stdlib/Test/#$"
+[[jl.type]]
+name = "Test.Error"
+uri = "stdlib/Test/#$"
+[[jl.type]]
+name = "Test.Fail"
+uri = "stdlib/Test/#$"
+[[jl.type]]
+name = "Test.GenericArray"
+uri = "stdlib/Test/#$"
+[[jl.type]]
+name = "Test.GenericDict"
+uri = "stdlib/Test/#$"
+[[jl.type]]
+name = "Test.GenericOrder"
+uri = "stdlib/Test/#$"
+[[jl.type]]
+name = "Test.GenericSet"
+uri = "stdlib/Test/#$"
+[[jl.type]]
+name = "Test.GenericString"
+uri = "stdlib/Test/#$"
+[[jl.type]]
+name = "Test.LogRecord"
+uri = "stdlib/Test/#$"
+[[jl.type]]
+name = "Test.Pass"
+uri = "stdlib/Test/#$"
+[[jl.type]]
+name = "Test.Result"
+uri = "stdlib/Test/#$"
+[[jl.type]]
+name = "Test.TestLogger"
+uri = "stdlib/Test/#$"
+[[jl.type]]
+name = "Test.TestSetException"
+uri = "stdlib/Test/#$"
+
+[[std.doc]]
+dispname = "Julia v1.10 Release Notes"
+name = "NEWS"
+uri = "NEWS/"
+[[std.doc]]
+dispname = "Arrays"
+name = "base/arrays"
+uri = "base/arrays/"
+[[std.doc]]
+dispname = "Essentials"
+name = "base/base"
+uri = "base/base/"
+[[std.doc]]
+dispname = "C Interface"
+name = "base/c"
+uri = "base/c/"
+[[std.doc]]
+dispname = "Collections and Data Structures"
+name = "base/collections"
+uri = "base/collections/"
+[[std.doc]]
+dispname = "Constants"
+name = "base/constants"
+uri = "base/constants/"
+[[std.doc]]
+dispname = "Filesystem"
+name = "base/file"
+uri = "base/file/"
+[[std.doc]]
+dispname = "I/O and Network"
+name = "base/io-network"
+uri = "base/io-network/"
+[[std.doc]]
+dispname = "Iteration utilities"
+name = "base/iterators"
+uri = "base/iterators/"
+[[std.doc]]
+dispname = "C Standard Library"
+name = "base/libc"
+uri = "base/libc/"
+[[std.doc]]
+dispname = "Mathematics"
+name = "base/math"
+uri = "base/math/"
+[[std.doc]]
+dispname = "Multi-Threading"
+name = "base/multi-threading"
+uri = "base/multi-threading/"
+[[std.doc]]
+dispname = "Numbers"
+name = "base/numbers"
+uri = "base/numbers/"
+[[std.doc]]
+dispname = "Tasks"
+name = "base/parallel"
+uri = "base/parallel/"
+[[std.doc]]
+dispname = "Punctuation"
+name = "base/punctuation"
+uri = "base/punctuation/"
+[[std.doc]]
+dispname = "Reflection and introspection"
+name = "base/reflection"
+uri = "base/reflection/"
+[[std.doc]]
+dispname = "SIMD Support"
+name = "base/simd-types"
+uri = "base/simd-types/"
+[[std.doc]]
+dispname = "Sorting and Related Functions"
+name = "base/sort"
+uri = "base/sort/"
+[[std.doc]]
+dispname = "StackTraces"
+name = "base/stacktraces"
+uri = "base/stacktraces/"
+[[std.doc]]
+dispname = "Strings"
+name = "base/strings"
+uri = "base/strings/"
+[[std.doc]]
+dispname = "EscapeAnalysis"
+name = "devdocs/EscapeAnalysis"
+uri = "devdocs/EscapeAnalysis/"
+[[std.doc]]
+dispname = "Julia ASTs"
+name = "devdocs/ast"
+uri = "devdocs/ast/"
+[[std.doc]]
+dispname = "Reporting and analyzing crashes (segfaults)"
+name = "devdocs/backtraces"
+uri = "devdocs/backtraces/"
+[[std.doc]]
+dispname = "Bounds checking"
+name = "devdocs/boundscheck"
+uri = "devdocs/boundscheck/"
+[[std.doc]]
+dispname = "ARM (Linux)"
+name = "devdocs/build/arm"
+uri = "devdocs/build/arm/"
+[[std.doc]]
+dispname = "Building Julia (Detailed)"
+name = "devdocs/build/build"
+uri = "devdocs/build/build/"
+[[std.doc]]
+dispname = "Binary distributions"
+name = "devdocs/build/distributing"
+uri = "devdocs/build/distributing/"
+[[std.doc]]
+dispname = "FreeBSD"
+name = "devdocs/build/freebsd"
+uri = "devdocs/build/freebsd/"
+[[std.doc]]
+dispname = "Linux"
+name = "devdocs/build/linux"
+uri = "devdocs/build/linux/"
+[[std.doc]]
+dispname = "macOS"
+name = "devdocs/build/macos"
+uri = "devdocs/build/macos/"
+[[std.doc]]
+dispname = "Windows"
+name = "devdocs/build/windows"
+uri = "devdocs/build/windows/"
+[[std.doc]]
+dispname = "Calling Conventions"
+name = "devdocs/callconv"
+uri = "devdocs/callconv/"
+[[std.doc]]
+dispname = "Base.Cartesian"
+name = "devdocs/cartesian"
+uri = "devdocs/cartesian/"
+[[std.doc]]
+dispname = "High-level Overview of the Native-Code Generation Process"
+name = "devdocs/compiler"
+uri = "devdocs/compiler/"
+[[std.doc]]
+dispname = "gdb debugging tips"
+name = "devdocs/debuggingtips"
+uri = "devdocs/debuggingtips/"
+[[std.doc]]
+dispname = "Eval of Julia code"
+name = "devdocs/eval"
+uri = "devdocs/eval/"
+[[std.doc]]
+dispname = "External Profiler Support"
+name = "devdocs/external_profilers"
+uri = "devdocs/external_profilers/"
+[[std.doc]]
+dispname = "Julia Functions"
+name = "devdocs/functions"
+uri = "devdocs/functions/"
+[[std.doc]]
+dispname = "Garbage Collection in Julia"
+name = "devdocs/gc"
+uri = "devdocs/gc/"
+[[std.doc]]
+dispname = "Static analyzer annotations for GC correctness in C code"
+name = "devdocs/gc-sa"
+uri = "devdocs/gc-sa/"
+[[std.doc]]
+dispname = "Inference"
+name = "devdocs/inference"
+uri = "devdocs/inference/"
+[[std.doc]]
+dispname = "Initialization of the Julia runtime"
+name = "devdocs/init"
+uri = "devdocs/init/"
+[[std.doc]]
+dispname = "isbits Union Optimizations"
+name = "devdocs/isbitsunionarrays"
+uri = "devdocs/isbitsunionarrays/"
+[[std.doc]]
+dispname = "Working with LLVM"
+name = "devdocs/llvm"
+uri = "devdocs/llvm/"
+[[std.doc]]
+dispname = "Proper maintenance and care of multi-threading locks"
+name = "devdocs/locks"
+uri = "devdocs/locks/"
+[[std.doc]]
+dispname = "Talking to the compiler (the :meta mechanism)"
+name = "devdocs/meta"
+uri = "devdocs/meta/"
+[[std.doc]]
+dispname = "Memory layout of Julia Objects"
+name = "devdocs/object"
+uri = "devdocs/object/"
+[[std.doc]]
+dispname = "Arrays with custom indices"
+name = "devdocs/offset-arrays"
+uri = "devdocs/offset-arrays/"
+[[std.doc]]
+dispname = "Package Images"
+name = "devdocs/pkgimg"
+uri = "devdocs/pkgimg/"
+[[std.doc]]
+dispname = "Fixing precompilation hangs due to open tasks or IO"
+name = "devdocs/precompile_hang"
+uri = "devdocs/precompile_hang/"
+[[std.doc]]
+dispname = "Instrumenting Julia with DTrace, and bpftrace"
+name = "devdocs/probes"
+uri = "devdocs/probes/"
+[[std.doc]]
+dispname = "Module loading"
+name = "devdocs/require"
+uri = "devdocs/require/"
+[[std.doc]]
+dispname = "Sanitizer support"
+name = "devdocs/sanitizers"
+uri = "devdocs/sanitizers/"
+[[std.doc]]
+dispname = "Julia SSA-form IR"
+name = "devdocs/ssair"
+uri = "devdocs/ssair/"
+[[std.doc]]
+dispname = "printf() and stdio in the Julia runtime"
+name = "devdocs/stdio"
+uri = "devdocs/stdio/"
+[[std.doc]]
+dispname = "SubArrays"
+name = "devdocs/subarrays"
+uri = "devdocs/subarrays/"
+[[std.doc]]
+dispname = "System Image Building"
+name = "devdocs/sysimg"
+uri = "devdocs/sysimg/"
+[[std.doc]]
+dispname = "More about types"
+name = "devdocs/types"
+uri = "devdocs/types/"
+[[std.doc]]
+dispname = "Using Valgrind with Julia"
+name = "devdocs/valgrind"
+uri = "devdocs/valgrind/"
+[[std.doc]]
+dispname = "Julia Documentation"
+name = "index"
+uri = ""
+[[std.doc]]
+dispname = "Single- and multi-dimensional Arrays"
+name = "manual/arrays"
+uri = "manual/arrays/"
+[[std.doc]]
+dispname = "Asynchronous Programming"
+name = "manual/asynchronous-programming"
+uri = "manual/asynchronous-programming/"
+[[std.doc]]
+dispname = "Calling C and Fortran Code"
+name = "manual/calling-c-and-fortran-code"
+uri = "manual/calling-c-and-fortran-code/"
+[[std.doc]]
+dispname = "Code Loading"
+name = "manual/code-loading"
+uri = "manual/code-loading/"
+[[std.doc]]
+dispname = "Command-line Interface"
+name = "manual/command-line-interface"
+uri = "manual/command-line-interface/"
+[[std.doc]]
+dispname = "Complex and Rational Numbers"
+name = "manual/complex-and-rational-numbers"
+uri = "manual/complex-and-rational-numbers/"
+[[std.doc]]
+dispname = "Constructors"
+name = "manual/constructors"
+uri = "manual/constructors/"
+[[std.doc]]
+dispname = "Control Flow"
+name = "manual/control-flow"
+uri = "manual/control-flow/"
+[[std.doc]]
+dispname = "Conversion and Promotion"
+name = "manual/conversion-and-promotion"
+uri = "manual/conversion-and-promotion/"
+[[std.doc]]
+dispname = "Multi-processing and Distributed Computing"
+name = "manual/distributed-computing"
+uri = "manual/distributed-computing/"
+[[std.doc]]
+dispname = "Documentation"
+name = "manual/documentation"
+uri = "manual/documentation/"
+[[std.doc]]
+dispname = "Embedding Julia"
+name = "manual/embedding"
+uri = "manual/embedding/"
+[[std.doc]]
+dispname = "Environment Variables"
+name = "manual/environment-variables"
+uri = "manual/environment-variables/"
+[[std.doc]]
+dispname = "Frequently Asked Questions"
+name = "manual/faq"
+uri = "manual/faq/"
+[[std.doc]]
+dispname = "Functions"
+name = "manual/functions"
+uri = "manual/functions/"
+[[std.doc]]
+dispname = "Getting Started"
+name = "manual/getting-started"
+uri = "manual/getting-started/"
+[[std.doc]]
+dispname = "Handling Operating System Variation"
+name = "manual/handling-operating-system-variation"
+uri = "manual/handling-operating-system-variation/"
+[[std.doc]]
+dispname = "Integers and Floating-Point Numbers"
+name = "manual/integers-and-floating-point-numbers"
+uri = "manual/integers-and-floating-point-numbers/"
+[[std.doc]]
+dispname = "Interfaces"
+name = "manual/interfaces"
+uri = "manual/interfaces/"
+[[std.doc]]
+dispname = "Mathematical Operations and Elementary Functions"
+name = "manual/mathematical-operations"
+uri = "manual/mathematical-operations/"
+[[std.doc]]
+dispname = "Metaprogramming"
+name = "manual/metaprogramming"
+uri = "manual/metaprogramming/"
+[[std.doc]]
+dispname = "Methods"
+name = "manual/methods"
+uri = "manual/methods/"
+[[std.doc]]
+dispname = "Missing Values"
+name = "manual/missing"
+uri = "manual/missing/"
+[[std.doc]]
+dispname = "Modules"
+name = "manual/modules"
+uri = "manual/modules/"
+[[std.doc]]
+dispname = "Multi-Threading"
+name = "manual/multi-threading"
+uri = "manual/multi-threading/"
+[[std.doc]]
+dispname = "Networking and Streams"
+name = "manual/networking-and-streams"
+uri = "manual/networking-and-streams/"
+[[std.doc]]
+dispname = "Noteworthy Differences from other Languages"
+name = "manual/noteworthy-differences"
+uri = "manual/noteworthy-differences/"
+[[std.doc]]
+dispname = "Parallel Computing"
+name = "manual/parallel-computing"
+uri = "manual/parallel-computing/"
+[[std.doc]]
+dispname = "Performance Tips"
+name = "manual/performance-tips"
+uri = "manual/performance-tips/"
+[[std.doc]]
+dispname = "Profiling"
+name = "manual/profile"
+uri = "manual/profile/"
+[[std.doc]]
+dispname = "Running External Programs"
+name = "manual/running-external-programs"
+uri = "manual/running-external-programs/"
+[[std.doc]]
+dispname = "Stack Traces"
+name = "manual/stacktraces"
+uri = "manual/stacktraces/"
+[[std.doc]]
+dispname = "Strings"
+name = "manual/strings"
+uri = "manual/strings/"
+[[std.doc]]
+dispname = "Style Guide"
+name = "manual/style-guide"
+uri = "manual/style-guide/"
+[[std.doc]]
+dispname = "Types"
+name = "manual/types"
+uri = "manual/types/"
+[[std.doc]]
+dispname = "Unicode Input"
+name = "manual/unicode-input"
+uri = "manual/unicode-input/"
+[[std.doc]]
+dispname = "Variables"
+name = "manual/variables"
+uri = "manual/variables/"
+[[std.doc]]
+dispname = "Scope of Variables"
+name = "manual/variables-and-scoping"
+uri = "manual/variables-and-scoping/"
+[[std.doc]]
+dispname = "Workflow Tips"
+name = "manual/workflow-tips"
+uri = "manual/workflow-tips/"
+[[std.doc]]
+dispname = "ArgTools"
+name = "stdlib/ArgTools"
+uri = "stdlib/ArgTools/"
+[[std.doc]]
+dispname = "Artifacts"
+name = "stdlib/Artifacts"
+uri = "stdlib/Artifacts/"
+[[std.doc]]
+dispname = "Base64"
+name = "stdlib/Base64"
+uri = "stdlib/Base64/"
+[[std.doc]]
+dispname = "CRC32c"
+name = "stdlib/CRC32c"
+uri = "stdlib/CRC32c/"
+[[std.doc]]
+dispname = "Dates"
+name = "stdlib/Dates"
+uri = "stdlib/Dates/"
+[[std.doc]]
+dispname = "Delimited Files"
+name = "stdlib/DelimitedFiles"
+uri = "stdlib/DelimitedFiles/"
+[[std.doc]]
+dispname = "Distributed Computing"
+name = "stdlib/Distributed"
+uri = "stdlib/Distributed/"
+[[std.doc]]
+dispname = "Downloads"
+name = "stdlib/Downloads"
+uri = "stdlib/Downloads/"
+[[std.doc]]
+dispname = "File Events"
+name = "stdlib/FileWatching"
+uri = "stdlib/FileWatching/"
+[[std.doc]]
+dispname = "Future"
+name = "stdlib/Future"
+uri = "stdlib/Future/"
+[[std.doc]]
+dispname = "Interactive Utilities"
+name = "stdlib/InteractiveUtils"
+uri = "stdlib/InteractiveUtils/"
+[[std.doc]]
+dispname = "Lazy Artifacts"
+name = "stdlib/LazyArtifacts"
+uri = "stdlib/LazyArtifacts/"
+[[std.doc]]
+dispname = "LibCURL"
+name = "stdlib/LibCURL"
+uri = "stdlib/LibCURL/"
+[[std.doc]]
+dispname = "LibGit2"
+name = "stdlib/LibGit2"
+uri = "stdlib/LibGit2/"
+[[std.doc]]
+dispname = "Dynamic Linker"
+name = "stdlib/Libdl"
+uri = "stdlib/Libdl/"
+[[std.doc]]
+dispname = "Linear Algebra"
+name = "stdlib/LinearAlgebra"
+uri = "stdlib/LinearAlgebra/"
+[[std.doc]]
+dispname = "Logging"
+name = "stdlib/Logging"
+uri = "stdlib/Logging/"
+[[std.doc]]
+dispname = "Markdown"
+name = "stdlib/Markdown"
+uri = "stdlib/Markdown/"
+[[std.doc]]
+dispname = "Memory-mapped I/O"
+name = "stdlib/Mmap"
+uri = "stdlib/Mmap/"
+[[std.doc]]
+dispname = "Network Options"
+name = "stdlib/NetworkOptions"
+uri = "stdlib/NetworkOptions/"
+[[std.doc]]
+dispname = "Pkg"
+name = "stdlib/Pkg"
+uri = "stdlib/Pkg/"
+[[std.doc]]
+dispname = "Printf"
+name = "stdlib/Printf"
+uri = "stdlib/Printf/"
+[[std.doc]]
+dispname = "Profiling"
+name = "stdlib/Profile"
+uri = "stdlib/Profile/"
+[[std.doc]]
+dispname = "The Julia REPL"
+name = "stdlib/REPL"
+uri = "stdlib/REPL/"
+[[std.doc]]
+dispname = "Random Numbers"
+name = "stdlib/Random"
+uri = "stdlib/Random/"
+[[std.doc]]
+dispname = "SHA"
+name = "stdlib/SHA"
+uri = "stdlib/SHA/"
+[[std.doc]]
+dispname = "Serialization"
+name = "stdlib/Serialization"
+uri = "stdlib/Serialization/"
+[[std.doc]]
+dispname = "Shared Arrays"
+name = "stdlib/SharedArrays"
+uri = "stdlib/SharedArrays/"
+[[std.doc]]
+dispname = "Sockets"
+name = "stdlib/Sockets"
+uri = "stdlib/Sockets/"
+[[std.doc]]
+dispname = "Sparse Arrays"
+name = "stdlib/SparseArrays"
+uri = "stdlib/SparseArrays/"
+[[std.doc]]
+dispname = "Statistics"
+name = "stdlib/Statistics"
+uri = "stdlib/Statistics/"
+[[std.doc]]
+dispname = "TOML"
+name = "stdlib/TOML"
+uri = "stdlib/TOML/"
+[[std.doc]]
+dispname = "Tar"
+name = "stdlib/Tar"
+uri = "stdlib/Tar/"
+[[std.doc]]
+dispname = "Unit Testing"
+name = "stdlib/Test"
+uri = "stdlib/Test/"
+[[std.doc]]
+dispname = "UUIDs"
+name = "stdlib/UUIDs"
+uri = "stdlib/UUIDs/"
+[[std.doc]]
+dispname = "Unicode"
+name = "stdlib/Unicode"
+uri = "stdlib/Unicode/"
+
+[[std.label]]
+name = "\"Value-types\""
+uri = "manual/types/#%22Value-types%22"
+[[std.label]]
+name = "...-combines-many-arguments-into-one-argument-in-function-definitions"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "...-splits-one-argument-into-many-different-arguments-in-function-calls"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "@ccall-/-@cfunction-argument-translation-guide"
+uri = "manual/calling-c-and-fortran-code/#%40ccall-%2F-%40cfunction-argument-translation-guide"
+[[std.label]]
+name = "@ccall-/-@cfunction-return-type-translation-guide"
+uri = "manual/calling-c-and-fortran-code/#%40ccall-%2F-%40cfunction-return-type-translation-guide"
+[[std.label]]
+name = "@threadcall"
+uri = "manual/multi-threading/#%40threadcall"
+[[std.label]]
+name = "@time"
+uri = "manual/profile/#%40time"
+[[std.label]]
+name = "A-basic-editor/REPL-workflow"
+uri = "manual/workflow-tips/#A-basic-editor%2FREPL-workflow"
+[[std.label]]
+name = "A-few-details"
+uri = "devdocs/subarrays/#$"
+[[std.label]]
+name = "A-simple-TCP-example"
+uri = "manual/networking-and-streams/#$"
+[[std.label]]
+name = "A-simple-sampler-without-pre-computed-data"
+uri = "stdlib/Random/#$"
+[[std.label]]
+name = "AArch64-(ARMv8)"
+uri = "devdocs/build/arm/#AArch64-%28ARMv8%29"
+[[std.label]]
+name = "ARM-(Linux)"
+uri = "devdocs/build/arm/#ARM-%28Linux%29"
+[[std.label]]
+name = "Abstract-containers-and-element-types"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Abstract-number-types"
+uri = "base/numbers/#$"
+[[std.label]]
+name = "AbstractLogger-interface"
+uri = "stdlib/Logging/#$"
+[[std.label]]
+name = "AbstractMenu-extension-interface"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "Accessing-Data-through-a-Pointer"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "Accessing-Documentation"
+uri = "manual/documentation/#$"
+[[std.label]]
+name = "Accessing-Global-Variables"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "Accessing-Returned-Arrays"
+uri = "manual/embedding/#$"
+[[std.label]]
+name = "Accumulation-and-clearing"
+uri = "manual/profile/#$"
+[[std.label]]
+name = "Adding-New-Zones"
+uri = "devdocs/external_profilers/#$"
+[[std.label]]
+name = "Adding-metadata-to-zones"
+uri = "devdocs/external_profilers/#$"
+[[std.label]]
+name = "Adding-methods"
+uri = "devdocs/functions/#$"
+[[std.label]]
+name = "Adding-probes-in-libjulia"
+uri = "devdocs/probes/#$"
+[[std.label]]
+name = "Additional-spurious-warnings"
+uri = "devdocs/valgrind/#$"
+[[std.label]]
+name = "Address-Sanitizer-(ASAN)"
+uri = "devdocs/sanitizers/#Address-Sanitizer-%28ASAN%29"
+[[std.label]]
+name = "Address-Sanitizer:-easy-build"
+uri = "devdocs/sanitizers/#Address-Sanitizer%3A-easy-build"
+[[std.label]]
+name = "Admonitions"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "Advanced-Usage"
+uri = "manual/documentation/#$"
+[[std.label]]
+name = "Advanced:-streaming-files"
+uri = "manual/networking-and-streams/#Advanced%3A-streaming-files"
+[[std.label]]
+name = "After-compiling"
+uri = "devdocs/build/windows/#$"
+[[std.label]]
+name = "All-HMAC-functions"
+uri = "stdlib/SHA/#$"
+[[std.label]]
+name = "All-Objects"
+uri = "base/base/#$"
+[[std.label]]
+name = "All-SHA-context-types"
+uri = "stdlib/SHA/#$"
+[[std.label]]
+name = "All-SHA-functions"
+uri = "stdlib/SHA/#$"
+[[std.label]]
+name = "Allocating-storage-using-generalizations-of-similar"
+uri = "devdocs/offset-arrays/#$"
+[[std.label]]
+name = "Allocation"
+uri = "devdocs/gc/#$"
+[[std.label]]
+name = "Alternate-Orderings"
+uri = "base/sort/#$"
+[[std.label]]
+name = "An-advanced-example"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "An-optimized-sampler-with-pre-computed-data"
+uri = "stdlib/Random/#$"
+[[std.label]]
+name = "Analysis-Design"
+uri = "devdocs/EscapeAnalysis/#$"
+[[std.label]]
+name = "Analysis-Usage"
+uri = "devdocs/EscapeAnalysis/#$"
+[[std.label]]
+name = "Annotate-values-taken-from-untyped-locations"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "Anonymous-function-expressions-as-macro-arguments"
+uri = "devdocs/cartesian/#$"
+[[std.label]]
+name = "Arbitrary-Precision-Arithmetic"
+uri = "manual/integers-and-floating-point-numbers/#$"
+[[std.label]]
+name = "Architecture-Customization"
+uri = "devdocs/build/linux/#$"
+[[std.label]]
+name = "ArgTools"
+uri = "stdlib/ArgTools/#$"
+[[std.label]]
+name = "Argument-Handling"
+uri = "stdlib/ArgTools/#$"
+[[std.label]]
+name = "Argument-type-declarations"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "Arithmetic-Operators"
+uri = "manual/mathematical-operations/#$"
+[[std.label]]
+name = "Array-functions"
+uri = "base/arrays/#$"
+[[std.label]]
+name = "Array-traits"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "Arrays"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "Arrays-With-Missing-Values"
+uri = "manual/missing/#$"
+[[std.label]]
+name = "Artifacts"
+uri = "stdlib/Artifacts/#$"
+[[std.label]]
+name = "Asynchronous-I/O"
+uri = "manual/networking-and-streams/#Asynchronous-I%2FO"
+[[std.label]]
+name = "Atomic-Operations"
+uri = "manual/multi-threading/#$"
+[[std.label]]
+name = "Atomic-operations"
+uri = "base/multi-threading/#$"
+[[std.label]]
+name = "Available-probes"
+uri = "devdocs/probes/#$"
+[[std.label]]
+name = "Avoid-changing-the-type-of-a-variable"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "Avoid-confusion-about-whether-something-is-an-instance-or-a-type"
+uri = "manual/style-guide/#$"
+[[std.label]]
+name = "Avoid-elaborate-container-types"
+uri = "manual/style-guide/#$"
+[[std.label]]
+name = "Avoid-fields-with-abstract-containers"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "Avoid-fields-with-abstract-type"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "Avoid-strange-type-Unions"
+uri = "manual/style-guide/#$"
+[[std.label]]
+name = "Avoid-string-interpolation-for-I/O"
+uri = "manual/performance-tips/#Avoid-string-interpolation-for-I%2FO"
+[[std.label]]
+name = "Avoid-type-piracy"
+uri = "manual/style-guide/#$"
+[[std.label]]
+name = "Avoid-untyped-global-variables"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "Avoid-using-floats-for-numeric-literals-in-generic-code-when-possible"
+uri = "manual/style-guide/#$"
+[[std.label]]
+name = "Avoid-writing-overly-specific-types"
+uri = "manual/style-guide/#$"
+[[std.label]]
+name = "Avoiding-Deadlock-in-Pipelines"
+uri = "manual/running-external-programs/#$"
+[[std.label]]
+name = "BLAS-and-LAPACK"
+uri = "devdocs/build/build/#$"
+[[std.label]]
+name = "BLAS-functions"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "Background"
+uri = "devdocs/ssair/#$"
+[[std.label]]
+name = "Background-and-References"
+uri = "manual/integers-and-floating-point-numbers/#$"
+[[std.label]]
+name = "Backporting-commits"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Backward-Escape-Propagation"
+uri = "devdocs/EscapeAnalysis/#$"
+[[std.label]]
+name = "Base-Submodules"
+uri = "base/base/#$"
+[[std.label]]
+name = "Base.Cartesian"
+uri = "devdocs/cartesian/#$"
+[[std.label]]
+name = "Base._start"
+uri = "devdocs/init/#$"
+[[std.label]]
+name = "Base64"
+uri = "stdlib/Base64/#$"
+[[std.label]]
+name = "Basic-Functions"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "Basic-Stream-I/O"
+uri = "manual/networking-and-streams/#Basic-Stream-I%2FO"
+[[std.label]]
+name = "Basic-Task-operations"
+uri = "manual/asynchronous-programming/#$"
+[[std.label]]
+name = "Basic-Unit-Tests"
+uri = "stdlib/Test/#$"
+[[std.label]]
+name = "Basic-functions"
+uri = "base/arrays/#$"
+[[std.label]]
+name = "Basic-syntax"
+uri = "devdocs/cartesian/#$"
+[[std.label]]
+name = "Basic-usage"
+uri = "manual/profile/#$"
+[[std.label]]
+name = "Basics"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "Be-aware-of-when-Julia-avoids-specializing"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "Be-careful-with-type-equality"
+uri = "manual/style-guide/#$"
+[[std.label]]
+name = "BigFloats-and-BigInts"
+uri = "base/numbers/#$"
+[[std.label]]
+name = "Binary-distribution"
+uri = "devdocs/build/windows/#$"
+[[std.label]]
+name = "Binary-distributions"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Bitwise-Operators"
+uri = "manual/mathematical-operations/#$"
+[[std.label]]
+name = "Block-forms"
+uri = "devdocs/ast/#$"
+[[std.label]]
+name = "Block-quotes"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "Bold"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "Boolean-Operators"
+uri = "manual/mathematical-operations/#$"
+[[std.label]]
+name = "Bounds-checking"
+uri = "devdocs/boundscheck/#$"
+[[std.label]]
+name = "Bracketed-forms"
+uri = "devdocs/ast/#$"
+[[std.label]]
+name = "Break-functions-into-multiple-definitions"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "Broadcast-Styles"
+uri = "manual/interfaces/#$"
+[[std.label]]
+name = "Broadcast-and-vectorization"
+uri = "base/arrays/#$"
+[[std.label]]
+name = "Broadcasting"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "Broken-Locks"
+uri = "devdocs/locks/#$"
+[[std.label]]
+name = "Broken-Tests"
+uri = "stdlib/Test/#$"
+[[std.label]]
+name = "Browser-based-workflow"
+uri = "manual/workflow-tips/#$"
+[[std.label]]
+name = "Build-dependencies"
+uri = "devdocs/build/build/#$"
+[[std.label]]
+name = "Build-process-is-slow/eats-memory/hangs-my-computer"
+uri = "devdocs/build/windows/#Build-process-is-slow%2Feats-memory%2Fhangs-my-computer"
+[[std.label]]
+name = "Build-system-changes"
+uri = "NEWS/#$"
+[[std.label]]
+name = "Building-32-bit-Julia-on-a-64-bit-machine"
+uri = "devdocs/build/build/#$"
+[[std.label]]
+name = "Building-Julia"
+uri = "devdocs/build/build/#$"
+[[std.label]]
+name = "Building-Julia-(Detailed)"
+uri = "devdocs/build/build/#Building-Julia-%28Detailed%29"
+[[std.label]]
+name = "Building-Julia-from-source-with-a-Git-checkout-of-a-stdlib"
+uri = "devdocs/build/build/#$"
+[[std.label]]
+name = "Building-Julia-with-Tracy"
+uri = "devdocs/external_profilers/#$"
+[[std.label]]
+name = "Building-Julia-with-a-different-version-of-LLVM"
+uri = "devdocs/llvm/#$"
+[[std.label]]
+name = "Building-a-similar-type-with-a-different-type-parameter"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Building-an-\"assert-build\"-of-Julia"
+uri = "devdocs/build/build/#Building-an-%22assert-build%22-of-Julia"
+[[std.label]]
+name = "Building-an-advanced-macro"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "Building-test-binaries"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Building-the-Julia-system-image"
+uri = "devdocs/sysimg/#$"
+[[std.label]]
+name = "Built-in-Exceptions"
+uri = "manual/control-flow/#$"
+[[std.label]]
+name = "Builtins"
+uri = "devdocs/functions/#$"
+[[std.label]]
+name = "C"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "C-ABI"
+uri = "devdocs/callconv/#$"
+[[std.label]]
+name = "C-Interface"
+uri = "base/c/#$"
+[[std.label]]
+name = "C-Standard-Library"
+uri = "base/libc/#$"
+[[std.label]]
+name = "C-Wrapper-Examples"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "CPU-Profiling"
+uri = "stdlib/Profile/#$"
+[[std.label]]
+name = "CRC32c"
+uri = "stdlib/CRC32c/#$"
+[[std.label]]
+name = "Calling-C-and-Fortran-Code"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "Calling-Conventions"
+uri = "devdocs/callconv/#$"
+[[std.label]]
+name = "Calling-Julia-Functions"
+uri = "manual/embedding/#$"
+[[std.label]]
+name = "Calling-a-particular-method"
+uri = "devdocs/debuggingtips/#$"
+[[std.label]]
+name = "Calls"
+uri = "devdocs/ast/#$"
+[[std.label]]
+name = "Can-I-use-using-or-import-inside-a-function?"
+uri = "manual/faq/#Can-I-use-using-or-import-inside-a-function%3F"
+[[std.label]]
+name = "Cartesian-indexing"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "Cartesian-indices"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "Case-Study:-Rational"
+uri = "manual/constructors/#Case-Study%3A-Rational"
+[[std.label]]
+name = "Case-Study:-Rational-Promotions"
+uri = "manual/conversion-and-promotion/#Case-Study%3A-Rational-Promotions"
+[[std.label]]
+name = "Catching-errors"
+uri = "devdocs/offset-arrays/#$"
+[[std.label]]
+name = "Caution!"
+uri = "devdocs/boundscheck/#Caution%21"
+[[std.label]]
+name = "Chaining-comparisons"
+uri = "manual/mathematical-operations/#$"
+[[std.label]]
+name = "Changing-the-contextual-module-which-is-active-at-the-REPL"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "Channels"
+uri = "base/parallel/#$"
+[[std.label]]
+name = "Channels-and-RemoteChannels"
+uri = "manual/distributed-computing/#$"
+[[std.label]]
+name = "Checking-for-package-breakages"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Checking-for-performance-regressions"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Cherry-picking-commits"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Closing-a-Library"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "Closure-cfunctions"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "Closures"
+uri = "devdocs/functions/#$"
+[[std.label]]
+name = "Cluster-Manager-Interface"
+uri = "stdlib/Distributed/#$"
+[[std.label]]
+name = "Cluster-Managers-with-Custom-Transports"
+uri = "manual/distributed-computing/#$"
+[[std.label]]
+name = "ClusterManagers"
+uri = "manual/distributed-computing/#$"
+[[std.label]]
+name = "Cmd-Objects"
+uri = "manual/running-external-programs/#$"
+[[std.label]]
+name = "Code-Generation"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "Code-blocks"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "Code-loading"
+uri = "base/base/#$"
+[[std.label]]
+name = "CodeInfo"
+uri = "devdocs/ast/#$"
+[[std.label]]
+name = "CodeInstance"
+uri = "devdocs/ast/#$"
+[[std.label]]
+name = "Collections-and-Data-Structures"
+uri = "base/collections/#$"
+[[std.label]]
+name = "Combinatorics"
+uri = "base/arrays/#$"
+[[std.label]]
+name = "Command-line-option-changes"
+uri = "NEWS/#$"
+[[std.label]]
+name = "Common-Date-Formatters"
+uri = "stdlib/Dates/#$"
+[[std.label]]
+name = "Common-Operations"
+uri = "manual/strings/#$"
+[[std.label]]
+name = "Communicating-with-Channels"
+uri = "manual/asynchronous-programming/#$"
+[[std.label]]
+name = "Communication-and-synchronization"
+uri = "manual/multi-threading/#$"
+[[std.label]]
+name = "Comparison-with-[backtrace](@ref)"
+uri = "manual/stacktraces/#Comparison-with-%5Bbacktrace%5D%28%40ref%29"
+[[std.label]]
+name = "Compiler/Runtime-improvements"
+uri = "NEWS/#Compiler%2FRuntime-improvements"
+[[std.label]]
+name = "Compiling-with-MinGW/MSYS2"
+uri = "devdocs/build/windows/#Compiling-with-MinGW%2FMSYS2"
+[[std.label]]
+name = "Completeness-of-analysis"
+uri = "devdocs/gc-sa/#$"
+[[std.label]]
+name = "Complex-Example"
+uri = "manual/running-external-programs/#$"
+[[std.label]]
+name = "Complex-Numbers"
+uri = "manual/complex-and-rational-numbers/#$"
+[[std.label]]
+name = "Complex-and-Rational-Numbers"
+uri = "manual/complex-and-rational-numbers/#$"
+[[std.label]]
+name = "Complex-method-\"cascades\"-with-default-arguments"
+uri = "manual/methods/#Complex-method-%22cascades%22-with-default-arguments"
+[[std.label]]
+name = "Composite-Types"
+uri = "manual/types/#$"
+[[std.label]]
+name = "Computing-cluster"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "Concatenation-and-permutation"
+uri = "base/arrays/#$"
+[[std.label]]
+name = "Conclusion"
+uri = "manual/code-loading/#$"
+[[std.label]]
+name = "Concrete-number-types"
+uri = "base/numbers/#$"
+[[std.label]]
+name = "ConfiguredMenu-subtypes"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "Consider-StaticArrays.jl-for-small-fixed-size-vector/matrix-operations"
+uri = "manual/performance-tips/#Consider-StaticArrays.jl-for-small-fixed-size-vector%2Fmatrix-operations"
+[[std.label]]
+name = "Construction-and-Initialization"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "Constructors-for-types-unrelated-to-their-arguments"
+uri = "manual/conversion-and-promotion/#$"
+[[std.label]]
+name = "Constructors-that-don't-return-instances-of-their-own-type"
+uri = "manual/conversion-and-promotion/#Constructors-that-don%27t-return-instances-of-their-own-type"
+[[std.label]]
+name = "Control-Flow"
+uri = "manual/control-flow/#$"
+[[std.label]]
+name = "Control-Flow-and-Short-Circuiting-Operators"
+uri = "manual/missing/#$"
+[[std.label]]
+name = "Controlling-the-Garbage-Collector"
+uri = "manual/embedding/#$"
+[[std.label]]
+name = "Conversion"
+uri = "manual/conversion-and-promotion/#$"
+[[std.label]]
+name = "Conversion-Functions"
+uri = "stdlib/Dates/#$"
+[[std.label]]
+name = "Conversion-vs.-Construction"
+uri = "manual/conversion-and-promotion/#$"
+[[std.label]]
+name = "Converting-Types"
+uri = "manual/embedding/#$"
+[[std.label]]
+name = "Copying-data-is-not-always-bad"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "Core.eval"
+uri = "devdocs/init/#$"
+[[std.label]]
+name = "Correspondence-of-dense-and-sparse-methods"
+uri = "stdlib/SparseArrays/#$"
+[[std.label]]
+name = "Creating-C-Compatible-Julia-Function-Pointers"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "Creating-Custom-AbstractTestSet-Types"
+uri = "stdlib/Test/#$"
+[[std.label]]
+name = "Creating-Sample-Functions"
+uri = "stdlib/Test/#$"
+[[std.label]]
+name = "Creating-a-Test-Environment"
+uri = "stdlib/Test/#$"
+[[std.label]]
+name = "Creating-a-backports-branch"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Creating-events"
+uri = "stdlib/Logging/#$"
+[[std.label]]
+name = "Creating-generic-functions"
+uri = "devdocs/functions/#$"
+[[std.label]]
+name = "Creating-new-generators"
+uri = "stdlib/Random/#$"
+[[std.label]]
+name = "Cross-compiling-from-Unix-(Linux/Mac/WSL)"
+uri = "devdocs/build/windows/#Cross-compiling-from-Unix-%28Linux%2FMac%2FWSL%29"
+[[std.label]]
+name = "Custom-AbstractUnitRange-types"
+uri = "devdocs/offset-arrays/#$"
+[[std.label]]
+name = "Custom-sampler-types"
+uri = "stdlib/Random/#$"
+[[std.label]]
+name = "Customizable-binary-operators"
+uri = "base/math/#$"
+[[std.label]]
+name = "Customization"
+uri = "stdlib/Profile/#$"
+[[std.label]]
+name = "Customization-/-Configuration"
+uri = "stdlib/REPL/#Customization-%2F-Configuration"
+[[std.label]]
+name = "Customizing-Colors"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "Customizing-keybindings"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "Cygwin-to-MinGW-cross-compiling"
+uri = "devdocs/build/windows/#$"
+[[std.label]]
+name = "Data-Formats"
+uri = "base/numbers/#$"
+[[std.label]]
+name = "Data-Movement"
+uri = "manual/distributed-computing/#$"
+[[std.label]]
+name = "Data-race-freedom"
+uri = "manual/multi-threading/#$"
+[[std.label]]
+name = "DataType-fields"
+uri = "base/reflection/#$"
+[[std.label]]
+name = "DataType-layout"
+uri = "base/reflection/#$"
+[[std.label]]
+name = "Dates"
+uri = "stdlib/Dates/#$"
+[[std.label]]
+name = "Dates-Functions"
+uri = "stdlib/Dates/#$"
+[[std.label]]
+name = "Dates-and-Time-Types"
+uri = "stdlib/Dates/#$"
+[[std.label]]
+name = "Dealing-with-signals"
+uri = "devdocs/debuggingtips/#$"
+[[std.label]]
+name = "Debugging-LLVM-transformations-in-isolation"
+uri = "devdocs/llvm/#$"
+[[std.label]]
+name = "Debugging-a-cross-compiled-build-under-wine"
+uri = "devdocs/build/windows/#$"
+[[std.label]]
+name = "Debugging-and-profiling"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "Debugging-compiler.jl"
+uri = "devdocs/inference/#$"
+[[std.label]]
+name = "Debugging-during-Julia's-build-process-(bootstrap)"
+uri = "devdocs/debuggingtips/#Debugging-during-Julia%27s-build-process-%28bootstrap%29"
+[[std.label]]
+name = "Debugging-precompilation-errors"
+uri = "devdocs/debuggingtips/#$"
+[[std.label]]
+name = "Declared-structure"
+uri = "base/base/#$"
+[[std.label]]
+name = "Default-top-level-definitions-and-bare-modules"
+uri = "manual/modules/#$"
+[[std.label]]
+name = "Defining-Methods"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Defining-New-Conversions"
+uri = "manual/conversion-and-promotion/#$"
+[[std.label]]
+name = "Defining-Promotion-Rules"
+uri = "manual/conversion-and-promotion/#$"
+[[std.label]]
+name = "Defining-methods-in-local-scope"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Definitions"
+uri = "manual/code-loading/#$"
+[[std.label]]
+name = "Delimited-Files"
+uri = "stdlib/DelimitedFiles/#$"
+[[std.label]]
+name = "Deprecated-or-removed"
+uri = "NEWS/#$"
+[[std.label]]
+name = "Dequeues"
+uri = "base/collections/#$"
+[[std.label]]
+name = "Design-Patterns-with-Parametric-Methods"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Diagonal-types"
+uri = "devdocs/types/#$"
+[[std.label]]
+name = "Dictionaries"
+uri = "base/collections/#$"
+[[std.label]]
+name = "Dispatch-on-one-argument-at-a-time"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Display-equations"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "Displaying-Julia-variables"
+uri = "devdocs/debuggingtips/#$"
+[[std.label]]
+name = "Division-errors"
+uri = "manual/integers-and-floating-point-numbers/#$"
+[[std.label]]
+name = "Division-functions"
+uri = "manual/mathematical-operations/#$"
+[[std.label]]
+name = "Do-Block-Syntax-for-Function-Arguments"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "Do-I-want-to-use-the-Stable,-LTS,-or-nightly-version-of-Julia?"
+uri = "manual/faq/#Do-I-want-to-use-the-Stable%2C-LTS%2C-or-nightly-version-of-Julia%3F"
+[[std.label]]
+name = "Don't-expose-unsafe-operations-at-the-interface-level"
+uri = "manual/style-guide/#Don%27t-expose-unsafe-operations-at-the-interface-level"
+[[std.label]]
+name = "Don't-overload-methods-of-base-container-types"
+uri = "manual/style-guide/#Don%27t-overload-methods-of-base-container-types"
+[[std.label]]
+name = "Don't-overuse-..."
+uri = "manual/style-guide/#Don%27t-overuse-..."
+[[std.label]]
+name = "Don't-overuse-macros"
+uri = "manual/style-guide/#Don%27t-overuse-macros"
+[[std.label]]
+name = "Don't-overuse-try-catch"
+uri = "manual/style-guide/#Don%27t-overuse-try-catch"
+[[std.label]]
+name = "Don't-parenthesize-conditions"
+uri = "manual/style-guide/#Don%27t-parenthesize-conditions"
+[[std.label]]
+name = "Don't-use-unnecessary-static-parameters"
+uri = "manual/style-guide/#Don%27t-use-unnecessary-static-parameters"
+[[std.label]]
+name = "Don't-write-a-trivial-anonymous-function-x-f(x)-for-a-named-function-f"
+uri = "manual/style-guide/#Don%27t-write-a-trivial-anonymous-function-x-f%28x%29-for-a-named-function-f"
+[[std.label]]
+name = "Downloading-the-Julia-source-code"
+uri = "devdocs/build/build/#$"
+[[std.label]]
+name = "Downloads"
+uri = "stdlib/Downloads/#$"
+[[std.label]]
+name = "Durations/Comparisons"
+uri = "stdlib/Dates/#Durations%2FComparisons"
+[[std.label]]
+name = "Dynamic-Linker"
+uri = "stdlib/Libdl/#$"
+[[std.label]]
+name = "Dynamic-documentation"
+uri = "manual/documentation/#$"
+[[std.label]]
+name = "Dynamically-Enabling-and-Disabling-Zones"
+uri = "devdocs/external_profilers/#$"
+[[std.label]]
+name = "EA-Alias-Analysis"
+uri = "devdocs/EscapeAnalysis/#$"
+[[std.label]]
+name = "EA-Array-Analysis"
+uri = "devdocs/EscapeAnalysis/#$"
+[[std.label]]
+name = "EA-Exception-Handling"
+uri = "devdocs/EscapeAnalysis/#$"
+[[std.label]]
+name = "ENABLE_GDBLISTENER"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "ENABLE_JITPROFILING"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "Early-filtering-and-message-handling"
+uri = "stdlib/Logging/#$"
+[[std.label]]
+name = "Elementary-Functions"
+uri = "manual/mathematical-operations/#$"
+[[std.label]]
+name = "Elementary-operations"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "Eliding-bounds-checks"
+uri = "devdocs/boundscheck/#$"
+[[std.label]]
+name = "Embedding-Julia"
+uri = "manual/embedding/#$"
+[[std.label]]
+name = "Emit-bounds-checks"
+uri = "devdocs/boundscheck/#$"
+[[std.label]]
+name = "Empty-generic-functions"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Enabling-stack-trace-samples"
+uri = "devdocs/external_profilers/#$"
+[[std.label]]
+name = "Enabling-support"
+uri = "devdocs/probes/#$"
+[[std.label]]
+name = "Environment-Variables"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "Environment-stacks"
+uri = "manual/code-loading/#$"
+[[std.label]]
+name = "Environment-variables"
+uri = "stdlib/Logging/#$"
+[[std.label]]
+name = "Environments"
+uri = "manual/code-loading/#$"
+[[std.label]]
+name = "Equality-and-Comparison-Operators"
+uri = "manual/missing/#$"
+[[std.label]]
+name = "Error-handling"
+uri = "manual/stacktraces/#$"
+[[std.label]]
+name = "Errors-during-Julia-startup"
+uri = "devdocs/backtraces/#$"
+[[std.label]]
+name = "EscapeAnalysis"
+uri = "devdocs/EscapeAnalysis/#$"
+[[std.label]]
+name = "Essentials"
+uri = "base/base/#$"
+[[std.label]]
+name = "Eval-of-Julia-code"
+uri = "devdocs/eval/#$"
+[[std.label]]
+name = "Evaluating-expressions"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "Evaluation-Scope-of-Default-Values"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "Events"
+uri = "base/base/#$"
+[[std.label]]
+name = "Example"
+uri = "manual/embedding/#$"
+[[std.label]]
+name = "Example-setup"
+uri = "devdocs/sanitizers/#$"
+[[std.label]]
+name = "Example:-Enable-debug-level-messages"
+uri = "stdlib/Logging/#Example%3A-Enable-debug-level-messages"
+[[std.label]]
+name = "Example:-OpenLibm"
+uri = "devdocs/build/build/#Example%3A-OpenLibm"
+[[std.label]]
+name = "Example:-Writing-log-events-to-a-file"
+uri = "stdlib/Logging/#Example%3A-Writing-log-events-to-a-file"
+[[std.label]]
+name = "Exception-Handling"
+uri = "manual/control-flow/#$"
+[[std.label]]
+name = "Exception-stacks-and-[current_exceptions](@ref)"
+uri = "manual/stacktraces/#Exception-stacks-and-%5Bcurrent_exceptions%5D%28%40ref%29"
+[[std.label]]
+name = "Exceptions"
+uri = "manual/embedding/#$"
+[[std.label]]
+name = "Execution"
+uri = "devdocs/jit/#$"
+[[std.label]]
+name = "Expansion-and-lowering"
+uri = "base/reflection/#$"
+[[std.label]]
+name = "Experimental-features"
+uri = "devdocs/require/#$"
+[[std.label]]
+name = "Export-lists"
+uri = "manual/modules/#$"
+[[std.label]]
+name = "Exporting-data-to-TOML-file"
+uri = "stdlib/TOML/#$"
+[[std.label]]
+name = "Expr-types"
+uri = "devdocs/ast/#$"
+[[std.label]]
+name = "Expressions-and-evaluation"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "External-Profiler-Support"
+uri = "devdocs/external_profilers/#$"
+[[std.label]]
+name = "External-Profiling"
+uri = "manual/profile/#$"
+[[std.label]]
+name = "External-applications"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "Extracting-the-type-parameter-from-a-super-type"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Extracting-useful-information"
+uri = "manual/stacktraces/#$"
+[[std.label]]
+name = "Federation-of-packages"
+uri = "manual/code-loading/#$"
+[[std.label]]
+name = "File-locations"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "Filesystem"
+uri = "base/file/#$"
+[[std.label]]
+name = "Fix-deprecation-warnings"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "Fixing-precompilation-hangs-due-to-open-tasks-or-IO"
+uri = "devdocs/precompile_hang/#$"
+[[std.label]]
+name = "Flags-that-impact-package-image-creation-and-selection"
+uri = "devdocs/pkgimg/#$"
+[[std.label]]
+name = "Floating-Point-Numbers"
+uri = "manual/integers-and-floating-point-numbers/#$"
+[[std.label]]
+name = "Floating-point-zero"
+uri = "manual/integers-and-floating-point-numbers/#$"
+[[std.label]]
+name = "Footnote-references"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "Footnotes"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "For-objects-that-mimic-AbstractArray-but-are-not-subtypes"
+uri = "devdocs/offset-arrays/#$"
+[[std.label]]
+name = "Fortran-Wrapper-Example"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "Free-variables"
+uri = "devdocs/types/#$"
+[[std.label]]
+name = "FreeBSD"
+uri = "devdocs/build/freebsd/#$"
+[[std.label]]
+name = "Frequently-Asked-Questions"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "Function-Testing"
+uri = "stdlib/ArgTools/#$"
+[[std.label]]
+name = "Function-calls"
+uri = "devdocs/functions/#$"
+[[std.label]]
+name = "Function-composition-and-piping"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "Function-like-objects"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Function-methods"
+uri = "base/reflection/#$"
+[[std.label]]
+name = "Functionality"
+uri = "stdlib/LibGit2/#$"
+[[std.label]]
+name = "Functions"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "Functions-on-Expressions"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "Further-Reading"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "Future"
+uri = "stdlib/Future/#$"
+[[std.label]]
+name = "GC-Invariants"
+uri = "devdocs/gc-sa/#$"
+[[std.label]]
+name = "GC-Logging"
+uri = "manual/profile/#$"
+[[std.label]]
+name = "GC-probes"
+uri = "devdocs/probes/#$"
+[[std.label]]
+name = "GC-root-placement"
+uri = "devdocs/llvm/#$"
+[[std.label]]
+name = "GC-stop-the-world-latency"
+uri = "devdocs/probes/#$"
+[[std.label]]
+name = "GDB-hangs-with-cygwin-mintty"
+uri = "devdocs/build/windows/#$"
+[[std.label]]
+name = "GDB-not-attaching-to-the-right-process"
+uri = "devdocs/build/windows/#$"
+[[std.label]]
+name = "GDB-not-showing-the-right-backtrace"
+uri = "devdocs/build/windows/#$"
+[[std.label]]
+name = "Garbage-Collection-Safety"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "Garbage-Collection-in-Julia"
+uri = "devdocs/gc/#$"
+[[std.label]]
+name = "Garbage-collector-mark-bits"
+uri = "devdocs/object/#$"
+[[std.label]]
+name = "General"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "General-Collections"
+uri = "base/collections/#$"
+[[std.label]]
+name = "General-I/O"
+uri = "base/io-network/#General-I%2FO"
+[[std.label]]
+name = "General-Information-for-Windows"
+uri = "devdocs/build/windows/#$"
+[[std.label]]
+name = "General-Number-Functions-and-Constants"
+uri = "base/numbers/#$"
+[[std.label]]
+name = "General-Overview"
+uri = "devdocs/gc-sa/#$"
+[[std.label]]
+name = "General-troubleshooting"
+uri = "devdocs/build/build/#$"
+[[std.label]]
+name = "Generalizing-existing-code"
+uri = "devdocs/offset-arrays/#$"
+[[std.label]]
+name = "Generated-functions"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "Generating-an-Example-Package"
+uri = "stdlib/Test/#$"
+[[std.label]]
+name = "Generating-random-values-of-custom-types"
+uri = "stdlib/Random/#$"
+[[std.label]]
+name = "Generating-values-for-an-AbstractFloat-type"
+uri = "stdlib/Random/#$"
+[[std.label]]
+name = "Generating-values-from-a-type"
+uri = "stdlib/Random/#$"
+[[std.label]]
+name = "Generator-Expressions"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "Generators-(creation-and-seeding)"
+uri = "stdlib/Random/#Generators-%28creation-and-seeding%29"
+[[std.label]]
+name = "Generic-Functions"
+uri = "base/base/#$"
+[[std.label]]
+name = "Getting-Around"
+uri = "base/base/#$"
+[[std.label]]
+name = "Global-Scope"
+uri = "manual/variables-and-scoping/#$"
+[[std.label]]
+name = "Global-Variables"
+uri = "manual/documentation/#$"
+[[std.label]]
+name = "Global-variables"
+uri = "manual/distributed-computing/#$"
+[[std.label]]
+name = "Glossary"
+uri = "devdocs/backtraces/#$"
+[[std.label]]
+name = "HMAC-functions"
+uri = "stdlib/SHA/#$"
+[[std.label]]
+name = "Handle-excess-argument-diversity-in-the-caller"
+uri = "manual/style-guide/#$"
+[[std.label]]
+name = "Handling-Operating-System-Variation"
+uri = "manual/handling-operating-system-variation/#$"
+[[std.label]]
+name = "Handling-name-conflicts"
+uri = "manual/modules/#$"
+[[std.label]]
+name = "Headers"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "Heap-Snapshots"
+uri = "stdlib/Profile/#$"
+[[std.label]]
+name = "Help-mode"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "Helper-Functions"
+uri = "stdlib/FileWatching/#$"
+[[std.label]]
+name = "Heuristics"
+uri = "devdocs/gc/#$"
+[[std.label]]
+name = "High-Level-Embedding"
+uri = "manual/embedding/#$"
+[[std.label]]
+name = "High-Level-Embedding-on-Windows-with-Visual-Studio"
+uri = "manual/embedding/#$"
+[[std.label]]
+name = "High-level-Overview-of-the-Native-Code-Generation-Process"
+uri = "devdocs/compiler/#$"
+[[std.label]]
+name = "High-level-overview"
+uri = "devdocs/pkgimg/#$"
+[[std.label]]
+name = "Hold-up:-why-macros?"
+uri = "manual/metaprogramming/#Hold-up%3A-why-macros%3F"
+[[std.label]]
+name = "Hooking-into-the-Random-API"
+uri = "stdlib/Random/#$"
+[[std.label]]
+name = "Horizontal-rules"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "How-can-I-constrain-or-compute-type-parameters?"
+uri = "manual/faq/#How-can-I-constrain-or-compute-type-parameters%3F"
+[[std.label]]
+name = "How-can-I-modify-the-declaration-of-a-type-in-my-session?"
+uri = "manual/faq/#How-can-I-modify-the-declaration-of-a-type-in-my-session%3F"
+[[std.label]]
+name = "How-can-I-transfer-the-list-of-installed-packages-after-updating-my-version-of-Julia?"
+uri = "manual/faq/#How-can-I-transfer-the-list-of-installed-packages-after-updating-my-version-of-Julia%3F"
+[[std.label]]
+name = "How-do-I-check-if-the-current-file-is-being-run-as-the-main-script?"
+uri = "manual/faq/#How-do-I-check-if-the-current-file-is-being-run-as-the-main-script%3F"
+[[std.label]]
+name = "How-do-I-delete-an-object-in-memory?"
+uri = "manual/faq/#How-do-I-delete-an-object-in-memory%3F"
+[[std.label]]
+name = "How-do-I-manage-precompilation-caches-in-distributed-file-systems?"
+uri = "manual/faq/#How-do-I-manage-precompilation-caches-in-distributed-file-systems%3F"
+[[std.label]]
+name = "How-do-I-pass-options-to-julia-using-#!/usr/bin/env?"
+uri = "manual/faq/#How-do-I-pass-options-to-julia-using-%23%21%2Fusr%2Fbin%2Fenv%3F"
+[[std.label]]
+name = "How-does-Julia-define-its-public-API?"
+uri = "manual/faq/#How-does-Julia-define-its-public-API%3F"
+[[std.label]]
+name = "How-inference-works"
+uri = "devdocs/inference/#$"
+[[std.label]]
+name = "Hygiene"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "I-passed-an-argument-x-to-a-function,-modified-it-inside-that-function,-but-on-the-outside,-the-variable-x-is-still-unchanged.-Why?"
+uri = "manual/faq/#I-passed-an-argument-x-to-a-function%2C-modified-it-inside-that-function%2C-but-on-the-outside%2C-the-variable-x-is-still-unchanged.-Why%3F"
+[[std.label]]
+name = "I/O-and-Network"
+uri = "base/io-network/#I%2FO-and-Network"
+[[std.label]]
+name = "IO-Output-Contextual-Properties"
+uri = "manual/networking-and-streams/#$"
+[[std.label]]
+name = "IPv6-Example"
+uri = "manual/networking-and-streams/#$"
+[[std.label]]
+name = "Images"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "Implementation"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "Implementation-overview"
+uri = "devdocs/sysimg/#$"
+[[std.label]]
+name = "Imports-and-such"
+uri = "devdocs/ast/#$"
+[[std.label]]
+name = "Improving-LLVM-optimizations-for-Julia"
+uri = "devdocs/llvm/#$"
+[[std.label]]
+name = "Incomplete-Initialization"
+uri = "manual/constructors/#$"
+[[std.label]]
+name = "Indentation"
+uri = "manual/style-guide/#$"
+[[std.label]]
+name = "Index-replacement"
+uri = "devdocs/subarrays/#$"
+[[std.label]]
+name = "Index-translation"
+uri = "devdocs/subarrays/#$"
+[[std.label]]
+name = "Indexable-Collections"
+uri = "base/collections/#$"
+[[std.label]]
+name = "Indexing"
+uri = "manual/interfaces/#$"
+[[std.label]]
+name = "Indexing-and-assignment"
+uri = "base/arrays/#$"
+[[std.label]]
+name = "Indirect-Calls"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "Inference"
+uri = "devdocs/inference/#$"
+[[std.label]]
+name = "Initialization-of-the-Julia-runtime"
+uri = "devdocs/init/#$"
+[[std.label]]
+name = "Inline-elements"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "Inserting-breakpoints-for-inspection-from-gdb"
+uri = "devdocs/debuggingtips/#$"
+[[std.label]]
+name = "Inserting-breakpoints-upon-certain-conditions"
+uri = "devdocs/debuggingtips/#$"
+[[std.label]]
+name = "Installing-the-Tracy-Profile-Viewer"
+uri = "devdocs/external_profilers/#$"
+[[std.label]]
+name = "Instrumenting-Julia-with-DTrace,-and-bpftrace"
+uri = "devdocs/probes/#Instrumenting-Julia-with-DTrace%2C-and-bpftrace"
+[[std.label]]
+name = "Integers-and-Floating-Point-Numbers"
+uri = "manual/integers-and-floating-point-numbers/#$"
+[[std.label]]
+name = "Intel-VTune-(ITTAPI)-Profiler"
+uri = "devdocs/external_profilers/#Intel-VTune-%28ITTAPI%29-Profiler"
+[[std.label]]
+name = "InteractiveUtils"
+uri = "NEWS/#$"
+[[std.label]]
+name = "Interface-between-JL_STD*-and-Julia-code"
+uri = "devdocs/stdio/#Interface-between-JL_STD%2A-and-Julia-code"
+[[std.label]]
+name = "Interfaces"
+uri = "manual/interfaces/#$"
+[[std.label]]
+name = "Intermediate-and-compiled-representations"
+uri = "base/reflection/#$"
+[[std.label]]
+name = "Internals"
+uri = "base/base/#$"
+[[std.label]]
+name = "Introduction-to-the-internal-machinery"
+uri = "devdocs/types/#$"
+[[std.label]]
+name = "Invariants"
+uri = "devdocs/llvm/#$"
+[[std.label]]
+name = "Investigating-results"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Is-Julia-named-after-someone-or-something?"
+uri = "manual/faq/#Is-Julia-named-after-someone-or-something%3F"
+[[std.label]]
+name = "Italics"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "Iterable-Collections"
+uri = "base/collections/#$"
+[[std.label]]
+name = "Iterated-dispatch"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Iteration"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "Iteration-utilities"
+uri = "base/iterators/#$"
+[[std.label]]
+name = "JIT-Design-and-Implementation"
+uri = "devdocs/jit/#$"
+[[std.label]]
+name = "JL-Call-Convention"
+uri = "devdocs/callconv/#$"
+[[std.label]]
+name = "JL_ALWAYS_LEAFTYPE"
+uri = "devdocs/gc-sa/#$"
+[[std.label]]
+name = "JL_GC_DISABLED"
+uri = "devdocs/gc-sa/#$"
+[[std.label]]
+name = "JL_GC_PROMISE_ROOTED"
+uri = "devdocs/gc-sa/#$"
+[[std.label]]
+name = "JL_GLOBALLY_ROOTED"
+uri = "devdocs/gc-sa/#$"
+[[std.label]]
+name = "JL_MAYBE_UNROOTED/JL_ROOTS_TEMPORARILY"
+uri = "devdocs/gc-sa/#JL_MAYBE_UNROOTED%2FJL_ROOTS_TEMPORARILY"
+[[std.label]]
+name = "JL_NOTSAFEPOINT"
+uri = "devdocs/gc-sa/#$"
+[[std.label]]
+name = "JL_PROPAGATES_ROOT"
+uri = "devdocs/gc-sa/#$"
+[[std.label]]
+name = "JL_REQUIRE_ROOTED_SLOT"
+uri = "devdocs/gc-sa/#$"
+[[std.label]]
+name = "JL_ROOTING_ARGUMENT/JL_ROOTED_ARGUMENT"
+uri = "devdocs/gc-sa/#JL_ROOTING_ARGUMENT%2FJL_ROOTED_ARGUMENT"
+[[std.label]]
+name = "JULIA_ANSWER_COLOR"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_BINDIR"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_CI"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_CPU_TARGET"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_DEBUG"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_DEPOT_PATH"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_EDITOR"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_ERROR_COLOR"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_EXCLUSIVE"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_GC_ALLOC_POOL,-JULIA_GC_ALLOC_OTHER,-JULIA_GC_ALLOC_PRINT"
+uri = "manual/environment-variables/#JULIA_GC_ALLOC_POOL%2C-JULIA_GC_ALLOC_OTHER%2C-JULIA_GC_ALLOC_PRINT"
+[[std.label]]
+name = "JULIA_GC_NO_GENERATIONAL"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_GC_WAIT_FOR_DEBUGGER"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_HISTORY"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_IMAGE_TIMINGS"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_INFO_COLOR"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_INPUT_COLOR"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_LLVM_ARGS"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_LOAD_PATH"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_NO_VERIFY_HOSTS-/-JULIA_SSL_NO_VERIFY_HOSTS-/-JULIA_SSH_NO_VERIFY_HOSTS-/-JULIA_ALWAYS_VERIFY_HOSTS"
+uri = "manual/environment-variables/#JULIA_NO_VERIFY_HOSTS-%2F-JULIA_SSL_NO_VERIFY_HOSTS-%2F-JULIA_SSH_NO_VERIFY_HOSTS-%2F-JULIA_ALWAYS_VERIFY_HOSTS"
+[[std.label]]
+name = "JULIA_NUM_PRECOMPILE_TASKS"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_NUM_THREADS"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_PKGRESOLVE_ACCURACY"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_PKG_DEVDIR"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_PKG_IGNORE_HASHES"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_PKG_OFFLINE"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_PKG_PRECOMPILE_AUTO"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_PKG_PRESERVE_TIERED_INSTALLED"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_PKG_SERVER"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_PKG_SERVER_REGISTRY_PREFERENCE"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_PKG_UNPACK_REGISTRY"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_PKG_USE_CLI_GIT"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_PROJECT"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_SHELL"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_SSL_CA_ROOTS_PATH"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_THREAD_SLEEP_THRESHOLD"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_VERBOSE_LINKING"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_WARN_COLOR"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "JULIA_WORKER_TIMEOUT"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "Julia-ASTs"
+uri = "devdocs/ast/#$"
+[[std.label]]
+name = "Julia-C/C:-Assembling-modules"
+uri = "manual/noteworthy-differences/#Julia-C%2FC%3A-Assembling-modules"
+[[std.label]]
+name = "Julia-C/C:-Module-interface"
+uri = "manual/noteworthy-differences/#Julia-C%2FC%3A-Module-interface"
+[[std.label]]
+name = "Julia-C/C:-Module-loading"
+uri = "manual/noteworthy-differences/#Julia-C%2FC%3A-Module-loading"
+[[std.label]]
+name = "Julia-C/C:-Namespaces"
+uri = "manual/noteworthy-differences/#Julia-C%2FC%3A-Namespaces"
+[[std.label]]
+name = "Julia-C/C:-Quick-reference"
+uri = "manual/noteworthy-differences/#Julia-C%2FC%3A-Quick-reference"
+[[std.label]]
+name = "Julia-Execution"
+uri = "devdocs/eval/#$"
+[[std.label]]
+name = "Julia-Functions"
+uri = "devdocs/functions/#$"
+[[std.label]]
+name = "Julia-Native-Calling-Convention"
+uri = "devdocs/callconv/#$"
+[[std.label]]
+name = "Julia-Releases"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "Julia-SSA-form-IR"
+uri = "devdocs/ssair/#$"
+[[std.label]]
+name = "Julia-v1.10-Release-Notes"
+uri = "NEWS/#$"
+[[std.label]]
+name = "Keeping-values-alive-in-the-absence-of-uses"
+uri = "devdocs/llvm/#$"
+[[std.label]]
+name = "Key-bindings"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "Keyword-Arguments"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "Keyword-arguments"
+uri = "devdocs/functions/#$"
+[[std.label]]
+name = "Keywords"
+uri = "base/base/#$"
+[[std.label]]
+name = "LAPACK-functions"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "LLVM"
+uri = "devdocs/build/build/#$"
+[[std.label]]
+name = "LLVM-Alias-Analysis"
+uri = "devdocs/llvm/#$"
+[[std.label]]
+name = "LLVM-Interface"
+uri = "base/c/#$"
+[[std.label]]
+name = "Language-changes"
+uri = "NEWS/#$"
+[[std.label]]
+name = "Lattice-Design"
+uri = "devdocs/EscapeAnalysis/#$"
+[[std.label]]
+name = "Lazy-Artifacts"
+uri = "stdlib/LazyArtifacts/#$"
+[[std.label]]
+name = "Legacy-interface"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "Legacy-ios.c-library"
+uri = "devdocs/stdio/#$"
+[[std.label]]
+name = "Let-Blocks"
+uri = "manual/variables-and-scoping/#$"
+[[std.label]]
+name = "Level-1-BLAS-functions"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "Level-2-BLAS-functions"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "Level-3-BLAS-functions"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "LibCURL"
+uri = "stdlib/LibCURL/#$"
+[[std.label]]
+name = "LibGit2"
+uri = "stdlib/LibGit2/#$"
+[[std.label]]
+name = "Libuv-wrappers-for-stdio"
+uri = "devdocs/stdio/#$"
+[[std.label]]
+name = "Line-by-Line-Allocation-Tracking"
+uri = "manual/profile/#$"
+[[std.label]]
+name = "Line-endings"
+uri = "devdocs/build/windows/#$"
+[[std.label]]
+name = "Line-numbers"
+uri = "devdocs/ast/#$"
+[[std.label]]
+name = "Linear-indexing-(LinearIndices)"
+uri = "devdocs/offset-arrays/#Linear-indexing-%28LinearIndices%29"
+[[std.label]]
+name = "LinearAlgebra"
+uri = "NEWS/#$"
+[[std.label]]
+name = "Links"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "Linux-Build-Troubleshooting"
+uri = "devdocs/build/linux/#$"
+[[std.label]]
+name = "Lists"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "Literal-zero-and-one"
+uri = "manual/integers-and-floating-point-numbers/#$"
+[[std.label]]
+name = "Literals"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "Loading-a-particular-file"
+uri = "devdocs/debuggingtips/#$"
+[[std.label]]
+name = "Local-invocations"
+uri = "manual/distributed-computing/#$"
+[[std.label]]
+name = "Locks"
+uri = "devdocs/locks/#$"
+[[std.label]]
+name = "Log-event-structure"
+uri = "stdlib/Logging/#$"
+[[std.label]]
+name = "Loggers"
+uri = "stdlib/Logging/#$"
+[[std.label]]
+name = "Logging-module"
+uri = "stdlib/Logging/#$"
+[[std.label]]
+name = "Logical-Operations-on-Arrays"
+uri = "manual/missing/#$"
+[[std.label]]
+name = "Logical-indexing"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "Logical-operators"
+uri = "manual/missing/#$"
+[[std.label]]
+name = "Loops-and-Comprehensions"
+uri = "manual/variables-and-scoping/#$"
+[[std.label]]
+name = "Low-level-matrix-operations"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "Low-level-synchronization-primitives"
+uri = "base/multi-threading/#$"
+[[std.label]]
+name = "Lowered-form"
+uri = "devdocs/ast/#$"
+[[std.label]]
+name = "MacOS"
+uri = "devdocs/pkgimg/#$"
+[[std.label]]
+name = "Machine-epsilon"
+uri = "manual/integers-and-floating-point-numbers/#$"
+[[std.label]]
+name = "Macro-generated-code"
+uri = "manual/documentation/#$"
+[[std.label]]
+name = "Macro-invocation"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "Macros-and-dispatch"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "Main-SSA-data-structure"
+uri = "devdocs/ssair/#$"
+[[std.label]]
+name = "Mapping-C-Functions-to-Julia"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "Markdown-Syntax-Extensions"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "Marking-and-Generational-Collection"
+uri = "devdocs/gc/#$"
+[[std.label]]
+name = "Mathematical-Functions"
+uri = "base/math/#$"
+[[std.label]]
+name = "Mathematical-Operations-and-Elementary-Functions"
+uri = "manual/mathematical-operations/#$"
+[[std.label]]
+name = "Mathematics"
+uri = "base/math/#$"
+[[std.label]]
+name = "Matrix-factorizations"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "Measure-performance-with-[@time](@ref)-and-pay-attention-to-memory-allocation"
+uri = "manual/performance-tips/#Measure-performance-with-%5B%40time%5D%28%40ref%29-and-pay-attention-to-memory-allocation"
+[[std.label]]
+name = "Memory"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "Memory-Management"
+uri = "manual/embedding/#$"
+[[std.label]]
+name = "Memory-Ownership"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "Memory-Sanitizer-(MSAN)"
+uri = "devdocs/sanitizers/#Memory-Sanitizer-%28MSAN%29"
+[[std.label]]
+name = "Memory-allocation-analysis"
+uri = "manual/profile/#$"
+[[std.label]]
+name = "Memory-layout"
+uri = "base/base/#$"
+[[std.label]]
+name = "Memory-layout-of-Julia-Objects"
+uri = "devdocs/object/#$"
+[[std.label]]
+name = "Memory-mapped-I/O"
+uri = "stdlib/Mmap/#Memory-mapped-I%2FO"
+[[std.label]]
+name = "Memory-profiling"
+uri = "stdlib/Profile/#$"
+[[std.label]]
+name = "Menus"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "Merging-backports-into-the-release-branch"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Meta"
+uri = "base/base/#$"
+[[std.label]]
+name = "Metaprogramming"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "Method-Tables"
+uri = "devdocs/functions/#$"
+[[std.label]]
+name = "MethodInstance"
+uri = "devdocs/ast/#$"
+[[std.label]]
+name = "Methods"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Missing-Values"
+uri = "base/base/#$"
+[[std.label]]
+name = "Mixing-multiple-using-and-import-statements"
+uri = "manual/modules/#$"
+[[std.label]]
+name = "Module-bindings"
+uri = "base/reflection/#$"
+[[std.label]]
+name = "Module-initialization-and-precompilation"
+uri = "manual/modules/#$"
+[[std.label]]
+name = "Module-loading"
+uri = "devdocs/require/#$"
+[[std.label]]
+name = "Module-loading-callbacks"
+uri = "devdocs/require/#$"
+[[std.label]]
+name = "Modules"
+uri = "manual/documentation/#$"
+[[std.label]]
+name = "More-About-Callbacks"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "More-about-types"
+uri = "devdocs/types/#$"
+[[std.label]]
+name = "More-dots:-Fuse-vectorized-operations"
+uri = "manual/performance-tips/#More-dots%3A-Fuse-vectorized-operations"
+[[std.label]]
+name = "More-on-Channels"
+uri = "manual/asynchronous-programming/#$"
+[[std.label]]
+name = "More-task-operations"
+uri = "manual/asynchronous-programming/#$"
+[[std.label]]
+name = "Mozilla's-Record-and-Replay-Framework-(rr)"
+uri = "devdocs/debuggingtips/#Mozilla%27s-Record-and-Replay-Framework-%28rr%29"
+[[std.label]]
+name = "Multi-processing-and-Distributed-Computing"
+uri = "manual/distributed-computing/#$"
+[[std.label]]
+name = "MultiSelectMenu"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "Multicast"
+uri = "manual/networking-and-streams/#$"
+[[std.label]]
+name = "Multidimensional-Arrays"
+uri = "manual/embedding/#$"
+[[std.label]]
+name = "Multimedia-I/O"
+uri = "base/io-network/#Multimedia-I%2FO"
+[[std.label]]
+name = "Multiple-GC-Threads"
+uri = "manual/multi-threading/#$"
+[[std.label]]
+name = "Multiple-Objects"
+uri = "manual/documentation/#$"
+[[std.label]]
+name = "Mutable-Composite-Types"
+uri = "manual/types/#$"
+[[std.label]]
+name = "Mutable-collections"
+uri = "manual/conversion-and-promotion/#$"
+[[std.label]]
+name = "Named-Tuple-Types"
+uri = "manual/types/#$"
+[[std.label]]
+name = "Named-Tuples"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "Nested-quote"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "Network-I/O"
+uri = "base/io-network/#Network-I%2FO"
+[[std.label]]
+name = "Network-Options"
+uri = "stdlib/NetworkOptions/#$"
+[[std.label]]
+name = "Network-Requirements-for-LocalManager-and-SSHManager"
+uri = "manual/distributed-computing/#$"
+[[std.label]]
+name = "Network-transport"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "Networking-and-Streams"
+uri = "manual/networking-and-streams/#$"
+[[std.label]]
+name = "New-IR-nodes"
+uri = "devdocs/ssair/#$"
+[[std.label]]
+name = "New-language-features"
+uri = "NEWS/#$"
+[[std.label]]
+name = "New-library-features"
+uri = "NEWS/#$"
+[[std.label]]
+name = "New-library-functions"
+uri = "NEWS/#$"
+[[std.label]]
+name = "Non-constant-Function-Specifications"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "Note-on-Optional-and-keyword-Arguments"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Notes-on-BLAS-and-LAPACK"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Notes-on-using-bpftrace"
+uri = "devdocs/probes/#$"
+[[std.label]]
+name = "Noteworthy-Differences-from-other-Languages"
+uri = "manual/noteworthy-differences/#$"
+[[std.label]]
+name = "Noteworthy-differences-from-C/C"
+uri = "manual/noteworthy-differences/#Noteworthy-differences-from-C%2FC"
+[[std.label]]
+name = "Noteworthy-differences-from-Common-Lisp"
+uri = "manual/noteworthy-differences/#$"
+[[std.label]]
+name = "Noteworthy-differences-from-MATLAB"
+uri = "manual/noteworthy-differences/#$"
+[[std.label]]
+name = "Noteworthy-differences-from-Python"
+uri = "manual/noteworthy-differences/#$"
+[[std.label]]
+name = "Noteworthy-differences-from-R"
+uri = "manual/noteworthy-differences/#$"
+[[std.label]]
+name = "Nothingness-and-missing-values"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "Number-of-indices"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "Numbered-prompt"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "Numbers"
+uri = "devdocs/ast/#$"
+[[std.label]]
+name = "Numeric-Comparisons"
+uri = "manual/mathematical-operations/#$"
+[[std.label]]
+name = "Numerical-Conversions"
+uri = "manual/mathematical-operations/#$"
+[[std.label]]
+name = "OS-X"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Object-allocation"
+uri = "devdocs/object/#$"
+[[std.label]]
+name = "Object-layout-(jl_value_t)"
+uri = "devdocs/object/#Object-layout-%28jl_value_t%29"
+[[std.label]]
+name = "Omitted-and-extra-indices"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "On-the-command-line"
+uri = "manual/embedding/#$"
+[[std.label]]
+name = "Operations-on-Types"
+uri = "manual/types/#$"
+[[std.label]]
+name = "Operator-Precedence-and-Associativity"
+uri = "manual/mathematical-operations/#$"
+[[std.label]]
+name = "Operators"
+uri = "devdocs/ast/#$"
+[[std.label]]
+name = "Operators-Are-Functions"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "Operators-With-Special-Names"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "Optimization-Pipeline"
+uri = "devdocs/jit/#$"
+[[std.label]]
+name = "Optimize-network-I/O-during-parallel-execution"
+uri = "manual/performance-tips/#Optimize-network-I%2FO-during-parallel-execution"
+[[std.label]]
+name = "Optional-Arguments"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "Optionally-generated-functions"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "Options-for-controlling-the-display-of-profile-results"
+uri = "manual/profile/#$"
+[[std.label]]
+name = "Order-Related-Functions"
+uri = "base/sort/#$"
+[[std.label]]
+name = "Other-Test-Macros"
+uri = "stdlib/Test/#$"
+[[std.label]]
+name = "Other-generic-segfaults-or-unreachables-reached"
+uri = "devdocs/backtraces/#$"
+[[std.label]]
+name = "Outer-only-constructors"
+uri = "manual/constructors/#$"
+[[std.label]]
+name = "Output-type-computation"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Overflow-behavior"
+uri = "manual/integers-and-floating-point-numbers/#$"
+[[std.label]]
+name = "Overview"
+uri = "devdocs/jit/#$"
+[[std.label]]
+name = "Overview-of-Julia-to-LLVM-Interface"
+uri = "devdocs/llvm/#$"
+[[std.label]]
+name = "Package-Manager"
+uri = "NEWS/#$"
+[[std.label]]
+name = "Package-directories"
+uri = "manual/code-loading/#$"
+[[std.label]]
+name = "Packages-and-Modules"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "Paragraphs"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "Parallel-Computing"
+uri = "manual/parallel-computing/#$"
+[[std.label]]
+name = "Parallel-Map-and-Loops"
+uri = "manual/distributed-computing/#$"
+[[std.label]]
+name = "Parallel-mode"
+uri = "manual/command-line-interface/#$"
+[[std.label]]
+name = "Parallelization"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "Parametric-Abstract-Types"
+uri = "manual/types/#$"
+[[std.label]]
+name = "Parametric-Constructors"
+uri = "manual/constructors/#$"
+[[std.label]]
+name = "Parametric-Methods"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Parametric-Primitive-Types"
+uri = "manual/types/#$"
+[[std.label]]
+name = "Parametric-Types"
+uri = "manual/types/#$"
+[[std.label]]
+name = "Parametrically-constrained-Varargs-methods"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Parsing-TOML-data"
+uri = "stdlib/TOML/#$"
+[[std.label]]
+name = "Passing-Pointers-for-Modifying-Inputs"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "Passing-options-to-LLVM"
+uri = "devdocs/llvm/#$"
+[[std.label]]
+name = "Performance-critical-code-should-be-inside-a-function"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "Period-Types"
+uri = "stdlib/Dates/#$"
+[[std.label]]
+name = "Periods"
+uri = "stdlib/Dates/#$"
+[[std.label]]
+name = "Phi-nodes-and-Pi-nodes"
+uri = "devdocs/ssair/#$"
+[[std.label]]
+name = "PhiC-nodes-and-Upsilon-nodes"
+uri = "devdocs/ssair/#$"
+[[std.label]]
+name = "Pidfile"
+uri = "stdlib/FileWatching/#$"
+[[std.label]]
+name = "Pipelines"
+uri = "manual/running-external-programs/#$"
+[[std.label]]
+name = "Pkg"
+uri = "stdlib/Pkg/#$"
+[[std.label]]
+name = "Pkg-mode"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "Pkg.jl"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "Platform-Specific-Notes"
+uri = "devdocs/build/build/#$"
+[[std.label]]
+name = "Point-releasing-101"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Powers,-logs-and-roots"
+uri = "manual/mathematical-operations/#Powers%2C-logs-and-roots"
+[[std.label]]
+name = "Pre-allocating-outputs"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "Prefer-exported-methods-over-direct-field-access"
+uri = "manual/style-guide/#$"
+[[std.label]]
+name = "Primary-Functions"
+uri = "stdlib/FileWatching/#$"
+[[std.label]]
+name = "Primitive-Types"
+uri = "manual/types/#$"
+[[std.label]]
+name = "Principles-of-usage"
+uri = "devdocs/cartesian/#$"
+[[std.label]]
+name = "Printf"
+uri = "NEWS/#$"
+[[std.label]]
+name = "Printing-of-debug-information"
+uri = "base/reflection/#$"
+[[std.label]]
+name = "Probe-usage-examples"
+uri = "devdocs/probes/#$"
+[[std.label]]
+name = "Processing-log-events"
+uri = "stdlib/Logging/#$"
+[[std.label]]
+name = "Profiling"
+uri = "manual/profile/#$"
+[[std.label]]
+name = "Profiling-Julia-with-Tracy"
+uri = "devdocs/external_profilers/#$"
+[[std.label]]
+name = "Profiling-package-precompilation-with-Tracy"
+uri = "devdocs/external_profilers/#$"
+[[std.label]]
+name = "Program-representation"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "Project-environments"
+uri = "manual/code-loading/#$"
+[[std.label]]
+name = "Promotion"
+uri = "manual/conversion-and-promotion/#$"
+[[std.label]]
+name = "Propagating-inbounds"
+uri = "devdocs/boundscheck/#$"
+[[std.label]]
+name = "Propagation-of-Missing-Values"
+uri = "manual/missing/#$"
+[[std.label]]
+name = "Proper-maintenance-and-care-of-multi-threading-locks"
+uri = "devdocs/locks/#$"
+[[std.label]]
+name = "Properties-of-Types"
+uri = "base/base/#$"
+[[std.label]]
+name = "Property-destructuring"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "Qualified-names"
+uri = "manual/modules/#$"
+[[std.label]]
+name = "Quirks"
+uri = "devdocs/pkgimg/#$"
+[[std.label]]
+name = "Quote-expressions"
+uri = "devdocs/ast/#$"
+[[std.label]]
+name = "REPL-based-workflow"
+uri = "manual/workflow-tips/#$"
+[[std.label]]
+name = "REPL-formatting"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "RadioMenu"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "Random-Numbers"
+uri = "stdlib/Random/#$"
+[[std.label]]
+name = "Random-generation-functions"
+uri = "stdlib/Random/#$"
+[[std.label]]
+name = "Random-numbers-module"
+uri = "stdlib/Random/#$"
+[[std.label]]
+name = "Raspberry-Pi-1-/-Raspberry-Pi-Zero"
+uri = "devdocs/build/arm/#Raspberry-Pi-1-%2F-Raspberry-Pi-Zero"
+[[std.label]]
+name = "Raspberry-Pi-2"
+uri = "devdocs/build/arm/#$"
+[[std.label]]
+name = "Rational-Numbers"
+uri = "manual/complex-and-rational-numbers/#$"
+[[std.label]]
+name = "Receiving-IP-Multicast-Packets"
+uri = "manual/networking-and-streams/#$"
+[[std.label]]
+name = "Redefining-Methods"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Reflection"
+uri = "base/base/#$"
+[[std.label]]
+name = "Reflection-and-introspection"
+uri = "base/reflection/#$"
+[[std.label]]
+name = "Remote-References-and-AbstractChannels"
+uri = "manual/distributed-computing/#$"
+[[std.label]]
+name = "Remote-References-and-Distributed-Garbage-Collection"
+uri = "manual/distributed-computing/#$"
+[[std.label]]
+name = "Renaming-with-as"
+uri = "manual/modules/#$"
+[[std.label]]
+name = "Reporting-and-analyzing-crashes-(segfaults)"
+uri = "devdocs/backtraces/#Reporting-and-analyzing-crashes-%28segfaults%29"
+[[std.label]]
+name = "Representation"
+uri = "devdocs/llvm/#$"
+[[std.label]]
+name = "Representation-of-Intermediate-Values"
+uri = "devdocs/compiler/#$"
+[[std.label]]
+name = "Representation-of-Pointers"
+uri = "devdocs/compiler/#$"
+[[std.label]]
+name = "Reproducibility"
+uri = "stdlib/Random/#$"
+[[std.label]]
+name = "Reproducing-concurrency-bugs-with-rr"
+uri = "devdocs/debuggingtips/#$"
+[[std.label]]
+name = "Required-Build-Tools-and-External-Libraries"
+uri = "devdocs/build/build/#$"
+[[std.label]]
+name = "Resolving-IP-Addresses"
+uri = "manual/networking-and-streams/#$"
+[[std.label]]
+name = "Resources"
+uri = "manual/getting-started/#$"
+[[std.label]]
+name = "Return-type"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "Returning-nothing"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "Revise-based-workflows"
+uri = "manual/workflow-tips/#$"
+[[std.label]]
+name = "Rounding"
+uri = "stdlib/Dates/#$"
+[[std.label]]
+name = "Rounding-Epoch"
+uri = "stdlib/Dates/#$"
+[[std.label]]
+name = "Rounding-Functions"
+uri = "stdlib/Dates/#$"
+[[std.label]]
+name = "Rounding-functions"
+uri = "manual/mathematical-operations/#$"
+[[std.label]]
+name = "Rounding-modes"
+uri = "manual/integers-and-floating-point-numbers/#$"
+[[std.label]]
+name = "Running-External-Programs"
+uri = "manual/running-external-programs/#$"
+[[std.label]]
+name = "Running-PackageEvaluator"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Running-the-Julia-test-suite-under-Valgrind"
+uri = "devdocs/valgrind/#$"
+[[std.label]]
+name = "Running-the-analysis"
+uri = "devdocs/gc-sa/#$"
+[[std.label]]
+name = "SHA"
+uri = "stdlib/SHA/#$"
+[[std.label]]
+name = "SHA-functions"
+uri = "stdlib/SHA/#$"
+[[std.label]]
+name = "SIMD-Support"
+uri = "base/simd-types/#$"
+[[std.label]]
+name = "SIMD-Values"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "Safe-use-of-Finalizers"
+uri = "manual/multi-threading/#$"
+[[std.label]]
+name = "Sanitizer-support"
+uri = "devdocs/sanitizers/#$"
+[[std.label]]
+name = "Scheduling"
+uri = "base/parallel/#$"
+[[std.label]]
+name = "Search-modes"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "Segfaults-during-bootstrap-(sysimg.jl)"
+uri = "devdocs/backtraces/#Segfaults-during-bootstrap-%28sysimg.jl%29"
+[[std.label]]
+name = "Segfaults-when-running-a-script"
+uri = "devdocs/backtraces/#$"
+[[std.label]]
+name = "Selecting-an-appropriate-output-array"
+uri = "manual/interfaces/#$"
+[[std.label]]
+name = "Sending-IP-Multicast-Packets"
+uri = "manual/networking-and-streams/#$"
+[[std.label]]
+name = "Separate-convert-and-kernel-logic"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Serialization"
+uri = "stdlib/Serialization/#$"
+[[std.label]]
+name = "Sessions-and-the-REPL"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "Set-Like-Collections"
+uri = "base/collections/#$"
+[[std.label]]
+name = "Setting-up-PackageEvaluator"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Shared-Arrays"
+uri = "stdlib/SharedArrays/#$"
+[[std.label]]
+name = "Shared-Arrays-and-Distributed-Garbage-Collection"
+uri = "manual/distributed-computing/#$"
+[[std.label]]
+name = "Shared-Global-Data-Structures"
+uri = "devdocs/locks/#$"
+[[std.label]]
+name = "Short-Circuit-Evaluation"
+uri = "manual/control-flow/#$"
+[[std.label]]
+name = "Side-effects-and-mutable-function-arguments"
+uri = "manual/multi-threading/#$"
+[[std.label]]
+name = "Sign-and-absolute-value-functions"
+uri = "manual/mathematical-operations/#$"
+[[std.label]]
+name = "Signing-binaries"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Skipping-Missing-Values"
+uri = "manual/missing/#$"
+[[std.label]]
+name = "Sockets"
+uri = "stdlib/Sockets/#$"
+[[std.label]]
+name = "Sorting-Algorithms"
+uri = "base/sort/#$"
+[[std.label]]
+name = "Sorting-Functions"
+uri = "base/sort/#$"
+[[std.label]]
+name = "Sorting-and-Related-Functions"
+uri = "base/sort/#$"
+[[std.label]]
+name = "Source-distribution"
+uri = "devdocs/build/windows/#$"
+[[std.label]]
+name = "Source-distributions-of-releases"
+uri = "devdocs/build/build/#$"
+[[std.label]]
+name = "Sparse-Arrays"
+uri = "stdlib/SparseArrays/#$"
+[[std.label]]
+name = "Sparse-Vector-Storage"
+uri = "stdlib/SparseArrays/#$"
+[[std.label]]
+name = "Sparse-Vector-and-Matrix-Constructors"
+uri = "stdlib/SparseArrays/#$"
+[[std.label]]
+name = "Sparse-matrix-operations"
+uri = "stdlib/SparseArrays/#$"
+[[std.label]]
+name = "Special-Types"
+uri = "base/base/#$"
+[[std.label]]
+name = "Special-floating-point-values"
+uri = "manual/integers-and-floating-point-numbers/#$"
+[[std.label]]
+name = "Special-functions"
+uri = "manual/mathematical-operations/#$"
+[[std.label]]
+name = "Special-matrices"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "Special-values"
+uri = "base/base/#$"
+[[std.label]]
+name = "Specialized-Calling-Convention-Signature-Representation"
+uri = "devdocs/compiler/#$"
+[[std.label]]
+name = "Specializing-array-generation"
+uri = "stdlib/Random/#$"
+[[std.label]]
+name = "Specializing-axes"
+uri = "devdocs/offset-arrays/#$"
+[[std.label]]
+name = "Specializing-reshape"
+uri = "devdocs/offset-arrays/#$"
+[[std.label]]
+name = "Specializing-similar"
+uri = "devdocs/offset-arrays/#$"
+[[std.label]]
+name = "Specifying-Network-Topology-(Experimental)"
+uri = "manual/distributed-computing/#Specifying-Network-Topology-%28Experimental%29"
+[[std.label]]
+name = "Specifying-multiple-system-image-targets"
+uri = "devdocs/sysimg/#$"
+[[std.label]]
+name = "Splatting-interpolation"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "Stack-Traces"
+uri = "manual/stacktraces/#$"
+[[std.label]]
+name = "StackTraces"
+uri = "base/stacktraces/#$"
+[[std.label]]
+name = "Standalone-using-and-import"
+uri = "manual/modules/#$"
+[[std.label]]
+name = "Standard-Modules"
+uri = "base/base/#$"
+[[std.label]]
+name = "Standard-Numeric-Types"
+uri = "base/numbers/#$"
+[[std.label]]
+name = "Standard-functions"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "Standard-library-changes"
+uri = "NEWS/#$"
+[[std.label]]
+name = "Standard-modules"
+uri = "manual/modules/#$"
+[[std.label]]
+name = "Starting-Julia-with-multiple-threads"
+uri = "manual/multi-threading/#$"
+[[std.label]]
+name = "Starting-and-managing-worker-processes"
+uri = "manual/distributed-computing/#$"
+[[std.label]]
+name = "Startup-file"
+uri = "manual/command-line-interface/#$"
+[[std.label]]
+name = "Static-Analysis-Algorithm"
+uri = "devdocs/gc-sa/#$"
+[[std.label]]
+name = "Static-analyzer-annotations-for-GC-correctness-in-C-code"
+uri = "devdocs/gc-sa/#$"
+[[std.label]]
+name = "Statistics"
+uri = "stdlib/Statistics/#$"
+[[std.label]]
+name = "Step-1:-Install-toolchain"
+uri = "devdocs/sanitizers/#Step-1%3A-Install-toolchain"
+[[std.label]]
+name = "Step-2:-Build-Julia-with-ASAN"
+uri = "devdocs/sanitizers/#Step-2%3A-Build-Julia-with-ASAN"
+[[std.label]]
+name = "String-Basics"
+uri = "manual/strings/#$"
+[[std.label]]
+name = "Strings"
+uri = "devdocs/ast/#$"
+[[std.label]]
+name = "Struct-Type-Correspondences"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "Style-Guide"
+uri = "manual/style-guide/#$"
+[[std.label]]
+name = "Stylistic-Conventions"
+uri = "manual/variables/#$"
+[[std.label]]
+name = "SubArray-design"
+uri = "devdocs/subarrays/#$"
+[[std.label]]
+name = "SubArrays"
+uri = "devdocs/subarrays/#$"
+[[std.label]]
+name = "Submodules-and-relative-paths"
+uri = "manual/modules/#$"
+[[std.label]]
+name = "Subsequences,-permutations-and-shuffling"
+uri = "stdlib/Random/#Subsequences%2C-permutations-and-shuffling"
+[[std.label]]
+name = "Subtypes"
+uri = "base/reflection/#$"
+[[std.label]]
+name = "Subtyping-and-method-sorting"
+uri = "devdocs/types/#$"
+[[std.label]]
+name = "Subtyping-diagonal-variables"
+uri = "devdocs/types/#$"
+[[std.label]]
+name = "Supplying-the-number-of-expressions"
+uri = "devdocs/cartesian/#$"
+[[std.label]]
+name = "Supporting-[ccall](@ref)"
+uri = "devdocs/llvm/#Supporting-%5Bccall%5D%28%40ref%29"
+[[std.label]]
+name = "Supporting-[pointer_from_objref](@ref)"
+uri = "devdocs/llvm/#Supporting-%5Bpointer_from_objref%5D%28%40ref%29"
+[[std.label]]
+name = "Suppressions"
+uri = "devdocs/valgrind/#$"
+[[std.label]]
+name = "Surface-syntax-AST"
+uri = "devdocs/ast/#$"
+[[std.label]]
+name = "Sweeping"
+uri = "devdocs/gc/#$"
+[[std.label]]
+name = "Symbols"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "Syntax"
+uri = "base/base/#$"
+[[std.label]]
+name = "Syntax-Conflicts"
+uri = "manual/integers-and-floating-point-numbers/#$"
+[[std.label]]
+name = "Syntax-Guide"
+uri = "manual/documentation/#$"
+[[std.label]]
+name = "System"
+uri = "base/base/#$"
+[[std.label]]
+name = "System-Image-Building"
+uri = "devdocs/sysimg/#$"
+[[std.label]]
+name = "System-and-Package-Image-Building"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "TOML"
+uri = "stdlib/TOML/#$"
+[[std.label]]
+name = "Tab-completion"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "Tables"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "Tagging-the-release"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Talking-to-the-compiler-(the-:meta-mechanism)"
+uri = "devdocs/meta/#Talking-to-the-compiler-%28the-%3Ameta-mechanism%29"
+[[std.label]]
+name = "Tar"
+uri = "stdlib/Tar/#$"
+[[std.label]]
+name = "Target-Architectures"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Target-Dependent-Optimization-and-Code-Generation"
+uri = "devdocs/jit/#$"
+[[std.label]]
+name = "Task-Monitor-with-BPFnative.jl"
+uri = "devdocs/probes/#$"
+[[std.label]]
+name = "Task-queue-probes"
+uri = "devdocs/probes/#$"
+[[std.label]]
+name = "Task-runtime-probes"
+uri = "devdocs/probes/#$"
+[[std.label]]
+name = "Task-spawn-monitor"
+uri = "devdocs/probes/#$"
+[[std.label]]
+name = "Tasks"
+uri = "base/parallel/#$"
+[[std.label]]
+name = "Tasks-and-events"
+uri = "manual/asynchronous-programming/#$"
+[[std.label]]
+name = "Test"
+uri = "NEWS/#$"
+[[std.label]]
+name = "Test-result-types"
+uri = "stdlib/Test/#$"
+[[std.label]]
+name = "Test-utilities"
+uri = "stdlib/Test/#$"
+[[std.label]]
+name = "Testing-Base-Julia"
+uri = "stdlib/Test/#$"
+[[std.label]]
+name = "Testing-Log-Statements"
+uri = "stdlib/Test/#$"
+[[std.label]]
+name = "Testing-log-events"
+uri = "stdlib/Logging/#$"
+[[std.label]]
+name = "The-@threads-Macro"
+uri = "manual/multi-threading/#The-%40threads-Macro"
+[[std.label]]
+name = "The-Julia-REPL"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "The-Julian-mode"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "The-[throw](@ref)-function"
+uri = "manual/control-flow/#The-%5Bthrow%5D%28%40ref%29-function"
+[[std.label]]
+name = "The-analyzer-annotations"
+uri = "devdocs/gc-sa/#$"
+[[std.label]]
+name = "The-bounds-checking-call-hierarchy"
+uri = "devdocs/boundscheck/#$"
+[[std.label]]
+name = "The-dangers-of-abusing-multiple-dispatch-(aka,-more-on-types-with-values-as-parameters)"
+uri = "manual/performance-tips/#The-dangers-of-abusing-multiple-dispatch-%28aka%2C-more-on-types-with-values-as-parameters%29"
+[[std.label]]
+name = "The-different-prompt-modes"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "The-documentation-is-not-accurate-enough.-Can-I-rely-on-the-existing-behavior?"
+uri = "manual/faq/#The-documentation-is-not-accurate-enough.-Can-I-rely-on-the-existing-behavior%3F"
+[[std.label]]
+name = "The-inlining-algorithm-(inline_worthy)"
+uri = "devdocs/inference/#The-inlining-algorithm-%28inline_worthy%29"
+[[std.label]]
+name = "The-jlcall-calling-convention"
+uri = "devdocs/llvm/#$"
+[[std.label]]
+name = "The-return-Keyword"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "The-try/catch-statement"
+uri = "manual/control-flow/#The-try%2Fcatch-statement"
+[[std.label]]
+name = "The-two-uses-of-the-...-operator:-slurping-and-splatting"
+uri = "manual/faq/#The-two-uses-of-the-...-operator%3A-slurping-and-splatting"
+[[std.label]]
+name = "The-uniform-scaling-operator"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "There-is-a-useful-undocumented-function/type/constant.-Can-I-use-it?"
+uri = "manual/faq/#There-is-a-useful-undocumented-function%2Ftype%2Fconstant.-Can-I-use-it%3F"
+[[std.label]]
+name = "Things-to-watch-out-for"
+uri = "devdocs/offset-arrays/#$"
+[[std.label]]
+name = "Thread-Sanitizer-(TSAN)"
+uri = "devdocs/sanitizers/#Thread-Sanitizer-%28TSAN%29"
+[[std.label]]
+name = "Thread-sleep/wake-probes"
+uri = "devdocs/probes/#Thread-sleep%2Fwake-probes"
+[[std.label]]
+name = "Throwing-Julia-Exceptions"
+uri = "manual/embedding/#$"
+[[std.label]]
+name = "Thundering-herd-detection"
+uri = "devdocs/probes/#$"
+[[std.label]]
+name = "TimeType-Period-Arithmetic"
+uri = "stdlib/Dates/#$"
+[[std.label]]
+name = "Toplevel-elements"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "Tracy-Profiler"
+uri = "devdocs/external_profilers/#$"
+[[std.label]]
+name = "Trait-based-dispatch"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Treat-Subnormal-Numbers-as-Zeros"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "Triggered-During-Execution"
+uri = "stdlib/Profile/#$"
+[[std.label]]
+name = "Trigonometric-and-hyperbolic-functions"
+uri = "manual/mathematical-operations/#$"
+[[std.label]]
+name = "Triple-Quoted-String-Literals"
+uri = "manual/strings/#$"
+[[std.label]]
+name = "Troubleshooting-\"method-not-matched\":-parametric-type-invariance-and-MethodErrors"
+uri = "manual/faq/#Troubleshooting-%22method-not-matched%22%3A-parametric-type-invariance-and-MethodErrors"
+[[std.label]]
+name = "Try-it-out!"
+uri = "devdocs/EscapeAnalysis/#Try-it-out%21"
+[[std.label]]
+name = "Tuple-Types"
+uri = "manual/types/#$"
+[[std.label]]
+name = "Tuple-and-NTuple-arguments"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "Tuple-types"
+uri = "devdocs/types/#$"
+[[std.label]]
+name = "Tuples"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "Tweaks"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "Type-Aliases"
+uri = "manual/types/#$"
+[[std.label]]
+name = "Type-Correspondences"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "Type-Declarations"
+uri = "manual/types/#$"
+[[std.label]]
+name = "Type-Parameters"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "Type-Unions"
+uri = "manual/types/#$"
+[[std.label]]
+name = "Type-declarations"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "Type-parameters-and-fields"
+uri = "devdocs/subarrays/#$"
+[[std.label]]
+name = "Type-relations"
+uri = "base/base/#$"
+[[std.label]]
+name = "TypeNames"
+uri = "devdocs/types/#$"
+[[std.label]]
+name = "Types"
+uri = "manual/documentation/#$"
+[[std.label]]
+name = "Types,-type-declarations,-and-constructors"
+uri = "manual/faq/#Types%2C-type-declarations%2C-and-constructors"
+[[std.label]]
+name = "Types-and-sets-(and-Any-and-Union{}/Bottom)"
+uri = "devdocs/types/#Types-and-sets-%28and-Any-and-Union%7B%7D%2FBottom%29"
+[[std.label]]
+name = "Types-of-functions"
+uri = "manual/types/#$"
+[[std.label]]
+name = "UUIDs"
+uri = "stdlib/UUIDs/#$"
+[[std.label]]
+name = "Unhandled-rr-system-calls"
+uri = "devdocs/valgrind/#$"
+[[std.label]]
+name = "Unicode"
+uri = "stdlib/Unicode/#$"
+[[std.label]]
+name = "Unicode-Input"
+uri = "manual/unicode-input/#$"
+[[std.label]]
+name = "Unicode-and-UTF-8"
+uri = "manual/strings/#$"
+[[std.label]]
+name = "Union-representation"
+uri = "devdocs/compiler/#$"
+[[std.label]]
+name = "UnionAll-Types"
+uri = "manual/types/#$"
+[[std.label]]
+name = "UnionAll-types"
+uri = "devdocs/types/#$"
+[[std.label]]
+name = "Unit-Testing"
+uri = "stdlib/Test/#$"
+[[std.label]]
+name = "Update-the-version-number-of-a-dependency"
+uri = "devdocs/build/build/#$"
+[[std.label]]
+name = "Updating-an-existing-source-tree"
+uri = "devdocs/build/build/#$"
+[[std.label]]
+name = "Updating-fields-of-GC-managed-objects"
+uri = "manual/embedding/#$"
+[[std.label]]
+name = "Updating-operators"
+uri = "manual/mathematical-operations/#$"
+[[std.label]]
+name = "Uploading-binaries"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Use-in-Makefiles"
+uri = "manual/embedding/#$"
+[[std.label]]
+name = "Use-naming-conventions-consistent-with-Julia-base/"
+uri = "manual/style-guide/#Use-naming-conventions-consistent-with-Julia-base%2F"
+[[std.label]]
+name = "Useful-JULIA_LLVM_ARGS-parameters"
+uri = "devdocs/llvm/#$"
+[[std.label]]
+name = "Useful-Julia-functions-for-Inspecting-those-variables"
+uri = "devdocs/debuggingtips/#$"
+[[std.label]]
+name = "Useful-Julia-variables-for-Inspecting"
+uri = "devdocs/debuggingtips/#$"
+[[std.label]]
+name = "Useful-references:"
+uri = "devdocs/probes/#Useful-references%3A"
+[[std.label]]
+name = "User-interaction"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "Using-@threads-without-data-races"
+uri = "manual/multi-threading/#Using-%40threads-without-data-races"
+[[std.label]]
+name = "Using-Loggers"
+uri = "stdlib/Logging/#$"
+[[std.label]]
+name = "Using-Valgrind-with-Julia"
+uri = "devdocs/valgrind/#$"
+[[std.label]]
+name = "Using-arguments-inside-scripts"
+uri = "manual/command-line-interface/#$"
+[[std.label]]
+name = "Using-axes-for-bounds-checks-and-loop-iteration"
+uri = "devdocs/offset-arrays/#$"
+[[std.label]]
+name = "Using-distinct-algorithms-for-scalar-or-array-generation"
+uri = "stdlib/Random/#$"
+[[std.label]]
+name = "Using-julia-config-to-automatically-determine-build-parameters"
+uri = "manual/embedding/#$"
+[[std.label]]
+name = "Utility-Collections"
+uri = "base/collections/#$"
+[[std.label]]
+name = "Vararg-Tuple-Types"
+uri = "manual/types/#$"
+[[std.label]]
+name = "Varargs-Functions"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "Variables-and-Assignments"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "Variadic-function-calls"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "Verifying"
+uri = "devdocs/probes/#$"
+[[std.label]]
+name = "Versioning"
+uri = "base/base/#$"
+[[std.label]]
+name = "Versioning-and-Git"
+uri = "devdocs/build/distributing/#$"
+[[std.label]]
+name = "Via-@profile"
+uri = "stdlib/Profile/#Via-%40profile"
+[[std.label]]
+name = "Viewing-Tracy-files-in-your-browser"
+uri = "devdocs/external_profilers/#$"
+[[std.label]]
+name = "Viewing-a-stack-trace"
+uri = "manual/stacktraces/#$"
+[[std.label]]
+name = "Views-(SubArrays-and-other-view-types)"
+uri = "base/arrays/#Views-%28SubArrays-and-other-view-types%29"
+[[std.label]]
+name = "What-are-the-possible-causes-of-an-UndefVarError-during-remote-execution?"
+uri = "manual/faq/#What-are-the-possible-causes-of-an-UndefVarError-during-remote-execution%3F"
+[[std.label]]
+name = "What-does-the-...-operator-do?"
+uri = "manual/faq/#What-does-the-...-operator-do%3F"
+[[std.label]]
+name = "What-is-the-difference-between-\"using\"-and-\"import\"?"
+uri = "manual/faq/#What-is-the-difference-between-%22using%22-and-%22import%22%3F"
+[[std.label]]
+name = "What-is-the-return-value-of-an-assignment?"
+uri = "manual/faq/#What-is-the-return-value-of-an-assignment%3F"
+[[std.label]]
+name = "When-is-convert-called?"
+uri = "manual/conversion-and-promotion/#When-is-convert-called%3F"
+[[std.label]]
+name = "When-to-use-T,-Ptr{T}-and-Ref{T}"
+uri = "manual/calling-c-and-fortran-code/#When-to-use-T%2C-Ptr%7BT%7D-and-Ref%7BT%7D"
+[[std.label]]
+name = "Why-am-I-getting-UndefVarError-from-a-simple-loop?"
+uri = "manual/faq/#Why-am-I-getting-UndefVarError-from-a-simple-loop%3F"
+[[std.label]]
+name = "Why-are-my-Julia-benchmarks-for-linear-algebra-operations-different-from-other-languages?"
+uri = "manual/faq/#Why-are-my-Julia-benchmarks-for-linear-algebra-operations-different-from-other-languages%3F"
+[[std.label]]
+name = "Why-do-concurrent-writes-to-the-same-stream-result-in-inter-mixed-output?"
+uri = "manual/faq/#Why-do-concurrent-writes-to-the-same-stream-result-in-inter-mixed-output%3F"
+[[std.label]]
+name = "Why-does-Julia-use-*-for-string-concatenation?-Why-not-or-something-else?"
+uri = "manual/faq/#Why-does-Julia-use-%2A-for-string-concatenation%3F-Why-not-or-something-else%3F"
+[[std.label]]
+name = "Why-does-x-y-allocate-memory-when-x-and-y-are-arrays?"
+uri = "manual/faq/#Why-does-x-y-allocate-memory-when-x-and-y-are-arrays%3F"
+[[std.label]]
+name = "Why-doesn't-it-work-to-declare-foo(bar::Vector{Real})-42-and-then-call-foo([1])?"
+uri = "manual/faq/#Why-doesn%27t-it-work-to-declare-foo%28bar%3A%3AVector%7BReal%7D%29-42-and-then-call-foo%28%5B1%5D%29%3F"
+[[std.label]]
+name = "Why-doesn't-run-support-*-or-pipes-for-scripting-external-programs?"
+uri = "manual/faq/#Why-doesn%27t-run-support-%2A-or-pipes-for-scripting-external-programs%3F"
+[[std.label]]
+name = "Why-don't-you-compile-Matlab/Python/R/…-code-to-Julia?"
+uri = "manual/faq/#Why-don%27t-you-compile-Matlab%2FPython%2FR%2F%E2%80%A6-code-to-Julia%3F"
+[[std.label]]
+name = "Windows-Build-Debugging"
+uri = "devdocs/build/windows/#$"
+[[std.label]]
+name = "Workflow-for-Testing-Packages"
+uri = "stdlib/Test/#$"
+[[std.label]]
+name = "Working-with-Arrays"
+uri = "manual/embedding/#$"
+[[std.label]]
+name = "Working-with-Broadcasted-objects"
+uri = "manual/interfaces/#$"
+[[std.label]]
+name = "Working-with-Files"
+uri = "manual/networking-and-streams/#$"
+[[std.label]]
+name = "Working-with-LLVM"
+uri = "devdocs/llvm/#$"
+[[std.label]]
+name = "Working-with-Test-Sets"
+uri = "stdlib/Test/#$"
+[[std.label]]
+name = "Working-with-context"
+uri = "stdlib/SHA/#$"
+[[std.label]]
+name = "Wrapper-types"
+uri = "manual/conversion-and-promotion/#$"
+[[std.label]]
+name = "Write-\"type-stable\"-functions"
+uri = "manual/performance-tips/#Write-%22type-stable%22-functions"
+[[std.label]]
+name = "Write-functions,-not-just-scripts"
+uri = "manual/style-guide/#Write-functions%2C-not-just-scripts"
+[[std.label]]
+name = "Write-functions-with-argument-ordering-similar-to-Julia-Base"
+uri = "manual/style-guide/#$"
+[[std.label]]
+name = "Writing-Documentation"
+uri = "manual/documentation/#$"
+[[std.label]]
+name = "Writing-Tests-for-greeting_tests.jl"
+uri = "stdlib/Test/#$"
+[[std.label]]
+name = "Writing-Tests-for-math_tests.jl"
+uri = "stdlib/Test/#$"
+[[std.label]]
+name = "Writing-custom-array-types-with-non-1-indexing"
+uri = "devdocs/offset-arrays/#$"
+[[std.label]]
+name = "\\LaTeX"
+uri = "stdlib/Markdown/#%5CLaTeX"
+[[std.label]]
+name = "allocation-profiler"
+uri = "manual/profile/#$"
+[[std.label]]
+name = "and-\\-characters"
+uri = "manual/documentation/#and-%5C-characters"
+[[std.label]]
+name = "ast-lowered-method"
+uri = "devdocs/ast/#$"
+[[std.label]]
+name = "automatic-type-conversion"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "bang-convention"
+uri = "manual/style-guide/#$"
+[[std.label]]
+name = "bit-(ARMv6,-ARMv7)"
+uri = "devdocs/build/arm/#bit-%28ARMv6%2C-ARMv7%29"
+[[std.label]]
+name = "calling-convention"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "catch-ctrl-c"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "ccall-interface"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "ccall-using-a-libuv-threadpool-(Experimental)"
+uri = "base/multi-threading/#ccall-using-a-libuv-threadpool-%28Experimental%29"
+[[std.label]]
+name = "cli"
+uri = "manual/command-line-interface/#$"
+[[std.label]]
+name = "code-availability"
+uri = "manual/distributed-computing/#$"
+[[std.label]]
+name = "code-loading"
+uri = "manual/code-loading/#$"
+[[std.label]]
+name = "command-interpolation"
+uri = "manual/running-external-programs/#$"
+[[std.label]]
+name = "command-line-interface"
+uri = "manual/command-line-interface/#$"
+[[std.label]]
+name = "compiler-efficiency-issues"
+uri = "devdocs/functions/#$"
+[[std.label]]
+name = "conversion-and-promotion"
+uri = "manual/conversion-and-promotion/#$"
+[[std.label]]
+name = "destructuring-assignment"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "dev-cartesian-reference"
+uri = "devdocs/cartesian/#$"
+[[std.label]]
+name = "dev-codegen"
+uri = "devdocs/eval/#$"
+[[std.label]]
+name = "dev-macro-expansion"
+uri = "devdocs/eval/#$"
+[[std.label]]
+name = "dev-parsing"
+uri = "devdocs/eval/#$"
+[[std.label]]
+name = "dev-sysimg"
+uri = "devdocs/eval/#$"
+[[std.label]]
+name = "dev-type-inference"
+uri = "devdocs/eval/#$"
+[[std.label]]
+name = "dev-version-info"
+uri = "devdocs/backtraces/#$"
+[[std.label]]
+name = "else-Clauses"
+uri = "manual/control-flow/#$"
+[[std.label]]
+name = "env-cpu-threads"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "env-gc-threads"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "env-image-threads"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "env-max-num-precompile-files"
+uri = "manual/environment-variables/#$"
+[[std.label]]
+name = "faq-array-0dim"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "faq-async-io"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "faq-domain-errors"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "faq-integer-arithmetic"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "faq-nothing"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "finally-Clauses"
+uri = "manual/control-flow/#$"
+[[std.label]]
+name = "gdb-debugging-tips"
+uri = "devdocs/debuggingtips/#$"
+[[std.label]]
+name = "isbits-Union-Arrays"
+uri = "devdocs/isbitsunionarrays/#$"
+[[std.label]]
+name = "isbits-Union-Optimizations"
+uri = "devdocs/isbitsunionarrays/#$"
+[[std.label]]
+name = "isbits-Union-Structs"
+uri = "devdocs/isbitsunionarrays/#$"
+[[std.label]]
+name = "jl_atexit_hook()"
+uri = "devdocs/init/#jl_atexit_hook%28%29"
+[[std.label]]
+name = "julia_init()"
+uri = "devdocs/init/#julia_init%28%29"
+[[std.label]]
+name = "julia_save()"
+uri = "devdocs/init/#julia_save%28%29"
+[[std.label]]
+name = "kernel-functions"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "lib-arrays"
+uri = "base/arrays/#$"
+[[std.label]]
+name = "lib-collections-iteration"
+uri = "base/collections/#$"
+[[std.label]]
+name = "lib-constants"
+uri = "base/constants/#$"
+[[std.label]]
+name = "lib-filewatching"
+uri = "stdlib/FileWatching/#$"
+[[std.label]]
+name = "lib-multithreading"
+uri = "base/multi-threading/#$"
+[[std.label]]
+name = "lib-numbers"
+uri = "base/numbers/#$"
+[[std.label]]
+name = "lib-profiling"
+uri = "stdlib/Profile/#$"
+[[std.label]]
+name = "lib-strings"
+uri = "base/strings/#$"
+[[std.label]]
+name = "lib-task-sync"
+uri = "base/parallel/#$"
+[[std.label]]
+name = "libuv"
+uri = "devdocs/build/build/#$"
+[[std.label]]
+name = "local-scope"
+uri = "manual/variables-and-scoping/#$"
+[[std.label]]
+name = "low-level-schedule-wait"
+uri = "base/parallel/#$"
+[[std.label]]
+name = "main()"
+uri = "devdocs/init/#main%28%29"
+[[std.label]]
+name = "man-abstract-types"
+uri = "manual/types/#$"
+[[std.label]]
+name = "man-advantages-of-julia"
+uri = "#$"
+[[std.label]]
+name = "man-allowed-variable-names"
+uri = "manual/variables/#$"
+[[std.label]]
+name = "man-ambiguities"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "man-anonymous-functions"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "man-api"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "man-argument-destructuring"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "man-argument-passing"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "man-array-and-vectorized-operators-and-functions"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "man-array-concatenation"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "man-array-indexing"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "man-array-literals"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "man-array-typed-literal"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "man-assignment-expressions"
+uri = "manual/variables/#$"
+[[std.label]]
+name = "man-asynchronous"
+uri = "manual/asynchronous-programming/#$"
+[[std.label]]
+name = "man-atomics"
+uri = "manual/multi-threading/#$"
+[[std.label]]
+name = "man-backends-linear-algebra"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "man-bits-types"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "man-byte-array-literals"
+uri = "manual/strings/#$"
+[[std.label]]
+name = "man-characters"
+uri = "manual/strings/#$"
+[[std.label]]
+name = "man-cluster-cookie"
+uri = "manual/distributed-computing/#$"
+[[std.label]]
+name = "man-code-warntype"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "man-compound-expressions"
+uri = "manual/control-flow/#$"
+[[std.label]]
+name = "man-comprehensions"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "man-concatenation"
+uri = "manual/strings/#$"
+[[std.label]]
+name = "man-conditional-evaluation"
+uri = "manual/control-flow/#$"
+[[std.label]]
+name = "man-constructors"
+uri = "manual/constructors/#$"
+[[std.label]]
+name = "man-csc"
+uri = "stdlib/SparseArrays/#$"
+[[std.label]]
+name = "man-custom-indices"
+uri = "devdocs/offset-arrays/#$"
+[[std.label]]
+name = "man-custom-pretty-printing"
+uri = "manual/types/#$"
+[[std.label]]
+name = "man-declared-types"
+uri = "manual/types/#$"
+[[std.label]]
+name = "man-distributed"
+uri = "stdlib/Distributed/#$"
+[[std.label]]
+name = "man-documentation"
+uri = "manual/documentation/#$"
+[[std.label]]
+name = "man-dot-operators"
+uri = "manual/mathematical-operations/#$"
+[[std.label]]
+name = "man-expression-interpolation"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "man-extensions"
+uri = "manual/code-loading/#$"
+[[std.label]]
+name = "man-functions"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "man-getting-started"
+uri = "manual/getting-started/#$"
+[[std.label]]
+name = "man-important-links"
+uri = "#$"
+[[std.label]]
+name = "man-indexed-assignment"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "man-inner-constructor-methods"
+uri = "manual/constructors/#$"
+[[std.label]]
+name = "man-instance-properties"
+uri = "manual/interfaces/#$"
+[[std.label]]
+name = "man-interactive-utils"
+uri = "stdlib/InteractiveUtils/#$"
+[[std.label]]
+name = "man-interface-array"
+uri = "manual/interfaces/#$"
+[[std.label]]
+name = "man-interface-iteration"
+uri = "manual/interfaces/#$"
+[[std.label]]
+name = "man-interface-strided-arrays"
+uri = "manual/interfaces/#$"
+[[std.label]]
+name = "man-interfaces-broadcasting"
+uri = "manual/interfaces/#$"
+[[std.label]]
+name = "man-introduction"
+uri = "#$"
+[[std.label]]
+name = "man-julia-compared-other-languages"
+uri = "#$"
+[[std.label]]
+name = "man-linalg"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "man-linalg-abstractq"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "man-linalg-factorizations"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "man-logging"
+uri = "stdlib/Logging/#$"
+[[std.label]]
+name = "man-loops"
+uri = "manual/control-flow/#$"
+[[std.label]]
+name = "man-macros"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "man-method-design-ambiguities"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "man-method-specializations"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "man-methods-orthogonalize"
+uri = "manual/methods/#$"
+[[std.label]]
+name = "man-multi-dim-arrays"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "man-multithreading"
+uri = "manual/multi-threading/#$"
+[[std.label]]
+name = "man-multithreading-linear-algebra"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "man-numeric-literal-coefficients"
+uri = "manual/integers-and-floating-point-numbers/#$"
+[[std.label]]
+name = "man-outer-constructor-methods"
+uri = "manual/constructors/#$"
+[[std.label]]
+name = "man-parametric-composite-types"
+uri = "manual/types/#$"
+[[std.label]]
+name = "man-performance-abstract-container"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "man-performance-annotations"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "man-performance-captured"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "man-performance-column-major"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "man-performance-tips"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "man-performance-value-type"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "man-performance-views"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "man-printf"
+uri = "stdlib/Printf/#$"
+[[std.label]]
+name = "man-punctuation"
+uri = "base/punctuation/#$"
+[[std.label]]
+name = "man-quote-node"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "man-raw-string-literals"
+uri = "manual/strings/#$"
+[[std.label]]
+name = "man-regex-literals"
+uri = "manual/strings/#$"
+[[std.label]]
+name = "man-scope-table"
+uri = "manual/variables-and-scoping/#$"
+[[std.label]]
+name = "man-scripting"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "man-shared-arrays"
+uri = "manual/distributed-computing/#$"
+[[std.label]]
+name = "man-shell-mode"
+uri = "stdlib/REPL/#$"
+[[std.label]]
+name = "man-singleton-types"
+uri = "manual/types/#$"
+[[std.label]]
+name = "man-strings"
+uri = "manual/strings/#$"
+[[std.label]]
+name = "man-supported-index-types"
+uri = "manual/arrays/#$"
+[[std.label]]
+name = "man-task-migration"
+uri = "manual/multi-threading/#$"
+[[std.label]]
+name = "man-tasks"
+uri = "manual/control-flow/#$"
+[[std.label]]
+name = "man-threadpools"
+uri = "manual/multi-threading/#$"
+[[std.label]]
+name = "man-type-stability"
+uri = "manual/faq/#$"
+[[std.label]]
+name = "man-typed-globals"
+uri = "manual/variables-and-scoping/#$"
+[[std.label]]
+name = "man-types"
+uri = "manual/types/#$"
+[[std.label]]
+name = "man-typet-type"
+uri = "manual/types/#$"
+[[std.label]]
+name = "man-variables"
+uri = "manual/variables/#$"
+[[std.label]]
+name = "man-vectorized"
+uri = "manual/functions/#$"
+[[std.label]]
+name = "man-version-number-literals"
+uri = "manual/strings/#$"
+[[std.label]]
+name = "man-what-makes-julia"
+uri = "#$"
+[[std.label]]
+name = "man-workflow-tips"
+uri = "manual/workflow-tips/#$"
+[[std.label]]
+name = "mapping-c-types-to-julia"
+uri = "manual/calling-c-and-fortran-code/#$"
+[[std.label]]
+name = "markdown_stdlib"
+uri = "stdlib/Markdown/#$"
+[[std.label]]
+name = "math-ops"
+uri = "base/math/#$"
+[[std.label]]
+name = "meta-non-standard-string-literals"
+uri = "manual/metaprogramming/#$"
+[[std.label]]
+name = "missing"
+uri = "manual/missing/#$"
+[[std.label]]
+name = "modules"
+uri = "manual/modules/#$"
+[[std.label]]
+name = "nVidia-Jetson-TX2"
+uri = "devdocs/build/arm/#$"
+[[std.label]]
+name = "namespace-management"
+uri = "manual/modules/#$"
+[[std.label]]
+name = "non-standard-string-literals"
+uri = "manual/strings/#$"
+[[std.label]]
+name = "on-soft-scope"
+uri = "manual/variables-and-scoping/#$"
+[[std.label]]
+name = "pchang_deps"
+uri = "devdocs/precompile_hang/#$"
+[[std.label]]
+name = "pchang_fix"
+uri = "devdocs/precompile_hang/#$"
+[[std.label]]
+name = "pkgimages"
+uri = "devdocs/pkgimg/#$"
+[[std.label]]
+name = "pkgimgs-multi-versioning"
+uri = "devdocs/pkgimg/#$"
+[[std.label]]
+name = "preferences"
+uri = "manual/code-loading/#$"
+[[std.label]]
+name = "printf()-and-stdio-in-the-Julia-runtime"
+uri = "devdocs/stdio/#printf%28%29-and-stdio-in-the-Julia-runtime"
+[[std.label]]
+name = "printf()-during-initialization"
+uri = "devdocs/stdio/#printf%28%29-during-initialization"
+[[std.label]]
+name = "repl_entrypoint()"
+uri = "devdocs/init/#repl_entrypoint%28%29"
+[[std.label]]
+name = "scope-of-variables"
+uri = "manual/variables-and-scoping/#$"
+[[std.label]]
+name = "stdlib-blas-chars"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "stdlib-blas-diag"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "stdlib-blas-side"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "stdlib-blas-trans"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "stdlib-blas-uplo"
+uri = "stdlib/LinearAlgebra/#$"
+[[std.label]]
+name = "stdlib-dates-api"
+uri = "stdlib/Dates/#$"
+[[std.label]]
+name = "stdlib-sparse-arrays"
+uri = "stdlib/SparseArrays/#$"
+[[std.label]]
+name = "string-interpolation"
+uri = "manual/strings/#$"
+[[std.label]]
+name = "sysimg-multi-versioning"
+uri = "devdocs/sysimg/#$"
+[[std.label]]
+name = "tools"
+uri = "manual/performance-tips/#$"
+[[std.label]]
+name = "using-and-import-with-specific-identifiers,-and-adding-methods"
+uri = "manual/modules/#using-and-import-with-specific-identifiers%2C-and-adding-methods"
+[[std.label]]
+name = "writing-binary-broadcasting-rules"
+uri = "manual/interfaces/#$"

--- a/docs/src/inventories/RecursiveArrayTools.toml
+++ b/docs/src/inventories/RecursiveArrayTools.toml
@@ -1,0 +1,76 @@
+# DocInventory version 1
+project = "RecursiveArrayTools.jl"
+version = "3.12.0"
+
+[[jl.function]]
+name = "RecursiveArrayTools.copyat_or_push!"
+uri = "recursive_array_functions/#RecursiveArrayTools.copyat_or_push%21"
+[[jl.function]]
+name = "RecursiveArrayTools.recursivecopy"
+uri = "recursive_array_functions/#$"
+[[jl.function]]
+name = "RecursiveArrayTools.recursivecopy!"
+uri = "recursive_array_functions/#RecursiveArrayTools.recursivecopy%21"
+[[jl.function]]
+name = "RecursiveArrayTools.vecvecapply"
+uri = "recursive_array_functions/#$"
+
+[[jl.type]]
+name = "RecursiveArrayTools.ArrayPartition"
+uri = "array_types/#$"
+[[jl.type]]
+name = "RecursiveArrayTools.DiffEqArray"
+uri = "array_types/#$"
+[[jl.type]]
+name = "RecursiveArrayTools.NamedArrayPartition"
+uri = "array_types/#$"
+[[jl.type]]
+name = "RecursiveArrayTools.VectorOfArray"
+uri = "array_types/#$"
+
+[[std.doc]]
+dispname = "Recursive Array Types"
+name = "array_types"
+uri = "array_types/"
+[[std.doc]]
+dispname = "Home"
+name = "index"
+uri = ""
+[[std.doc]]
+dispname = "Recursive Array Functions"
+name = "recursive_array_functions"
+uri = "recursive_array_functions/"
+
+[[std.label]]
+dispname = "Abstract Types"
+name = "Abstract-Types"
+uri = "array_types/#$"
+[[std.label]]
+dispname = "Concrete Types"
+name = "Concrete-Types"
+uri = "array_types/#$"
+[[std.label]]
+name = "Contributing"
+uri = "#$"
+[[std.label]]
+dispname = "Function List"
+name = "Function-List"
+uri = "recursive_array_functions/#$"
+[[std.label]]
+name = "Installation"
+uri = "#$"
+[[std.label]]
+dispname = "Recursive Array Functions"
+name = "Recursive-Array-Functions"
+uri = "recursive_array_functions/#$"
+[[std.label]]
+dispname = "Recursive Array Types"
+name = "Recursive-Array-Types"
+uri = "array_types/#$"
+[[std.label]]
+dispname = "RecursiveArrayTools.jl: Arrays of Arrays and Even Deeper"
+name = "RecursiveArrayTools.jl:-Arrays-of-Arrays-and-Even-Deeper"
+uri = "#RecursiveArrayTools.jl%3A-Arrays-of-Arrays-and-Even-Deeper"
+[[std.label]]
+name = "Reproducibility"
+uri = "#$"

--- a/ext/QuantumPropagatorsRecursiveArrayToolsExt.jl
+++ b/ext/QuantumPropagatorsRecursiveArrayToolsExt.jl
@@ -1,0 +1,11 @@
+module QuantumPropagatorsRecursiveArrayToolsExt
+
+using RecursiveArrayTools: ArrayPartition
+import QuantumPropagators.Controls: _combine_parameter_arrays
+
+
+function _combine_parameter_arrays(parameter_arrays)
+    return ArrayPartition(parameter_arrays...)
+end
+
+end

--- a/src/QuantumPropagators.jl
+++ b/src/QuantumPropagators.jl
@@ -45,6 +45,7 @@ include("ode_function.jl")
 module Interfaces
     export check_operator, check_state, check_tlist, check_amplitude
     export check_control, check_generator, check_propagator
+    export check_parameterized_function, check_parameterized
     include(joinpath("interfaces", "utils.jl"))
     include(joinpath("interfaces", "state.jl"))
     include(joinpath("interfaces", "tlist.jl"))
@@ -53,6 +54,7 @@ module Interfaces
     include(joinpath("interfaces", "control.jl"))
     include(joinpath("interfaces", "generator.jl"))
     include(joinpath("interfaces", "propagator.jl"))
+    include(joinpath("interfaces", "parameterization.jl"))
 end
 #! format: on
 

--- a/src/interfaces/amplitude.jl
+++ b/src/interfaces/amplitude.jl
@@ -20,6 +20,14 @@ of a [`Generator`](@ref) object. Specifically:
 * [`evaluate(ampl, tlist, n; vals_dict)`](@ref evaluate) must be defined and
   return a Number
 
+If `for_parameterization` (may require the `RecursiveArrayTools` package to be
+loaded):
+
+* [`get_parameters(ampl)`](@ref get_parameters) must be defined and return a
+  vector of floats. Mutating that vector must mutate the controls inside the
+  `ampl`.
+
+
 The function returns `true` for a valid amplitude and `false` for an invalid
 amplitude. Unless `quiet=true`, it will log an error to indicate which of the
 conditions failed.
@@ -27,6 +35,7 @@ conditions failed.
 function check_amplitude(
     ampl;
     tlist,
+    for_parameterization=false,
     quiet=false,
     _message_prefix=""  # for recursive calling
 )
@@ -47,6 +56,10 @@ function check_amplitude(
             exception = (exc, catch_abbreviated_backtrace())
         )
         success = false
+    end
+
+    if for_parameterization
+        success &= check_parameterized(ampl; _message_prefix=px)
     end
 
     try

--- a/src/interfaces/control.jl
+++ b/src/interfaces/control.jl
@@ -1,28 +1,48 @@
 using Test
 
-using ..Controls: discretize, discretize_on_midpoints, get_parameters
+using ..Controls: discretize, discretize_on_midpoints, get_parameters, ParameterizedFunction
 
 
 """Check that `control` can be evaluated on a time grid.
 
 ```julia
-@test check_control(control; tlist, quiet=false)
+@test check_control(
+    control;
+    tlist,
+    for_parameterization=true,
+    for_time_continuous=(control isa Function),
+    quiet=false
+)
 ```
 
 verifies the given `control` (one of the elements of the tuple returned by
 [`get_controls`](@ref)):
 
-* [`get_parameters(control)`](@ref get_parameters) must be defined and return a
-  vector of floats
+* [`evaluate(control, tlist, n)`](@ref evaluate) must be defined and return a
+  `Float64`
+* [`evaluate(control, tlist, n; vals_dict=IdDict(control => v))`](@ref evaluate)
+  must be defined and return `v`
 * [`discretize(control, tlist)`](@ref discretize) must be defined and return a
-  vector of floats of the same size as `tlist`.
+  vector of floats of the same size as `tlist`. Only if `length(tlist) > 2`.
 * all values in [`discretize(control, tlist)`](@ref discretize) must be finite
-  (`isfinite`)
+  (`isfinite`).
 * [`discretize_on_midpoints(control, tlist)`](@ref discretize_on_midpoints)
   must be defined and return a vector of floats with one element less than
-  `tlist`.
+  `tlist`. Only if `length(tlist) > 2`.
 * all values in [`discretize_on_midpoints(control, tlist)`](@ref discretize)
   must be finite (`isfinite`)
+
+If `for_time_continuous`:
+
+* [`evaluate(control, t)`](@ref evaluate) must be defined and return a
+  `Float64`
+* [`evaluate(control, t; vals_dict=IdDict(control => v))`](@ref evaluate)
+  must be defined and return `v`
+
+If `for_parameterization`:
+
+* [`get_parameters(control)`](@ref get_parameters) must be defined and return a
+  vector of floats. Mutating that vector must mutate the control.
 
 The function returns `true` for a valid control and `false` for an invalid
 control. Unless `quiet=true`, it will log an error to indicate which of the
@@ -31,6 +51,8 @@ conditions failed.
 function check_control(
     control;
     tlist,
+    for_parameterization=true,
+    for_time_continuous=(control isa Function),
     quiet=false,
     _message_prefix=""  # for recursive calling
 )
@@ -40,79 +62,130 @@ function check_control(
     px = _message_prefix
     success = true
 
+    if for_parameterization
+        if control isa ParameterizedFunction
+            success &=
+                check_parameterized_function(control; tlist, quiet, _message_prefix=px)
+        else
+            success &= check_parameterized(control; quiet, _message_prefix=px)
+        end
+    end
+
     try
-        parameters = get_parameters(control)
+        v = evaluate(control, tlist, 1)
+        if !(v isa Float64)
+            quiet ||
+                @error "$(px)`evaluate(control, tlist, n)` must return a Float64, not $(typeof(v))"
+            success = false
+        end
+    catch exc
+        quiet || @error(
+            "$(px)`evaluate(control, tlist, n)` must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
+        success = false
+    end
+    try
+        v₀ = rand()
+        v = evaluate(control, tlist, 1; vals_dict=IdDict(control => v₀))
+        if v != v₀
+            msg = "$(px)`evaluate(control, tlist, n; vals_dict=IdDict(control => v))` must return `v`"
+            quiet || @error msg v = v₀ result = v
+            success = false
+        end
+    catch exc
+        quiet || @error(
+            "$(px)`evaluate(control, tlist, n; vals_dict=IdDict(control => v))`  must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
+        success = false
+    end
+
+    if for_time_continuous
         try
-            # we only check `eltype` to allow for AbstractVector
-            if !(eltype(parameters) == Float64)
+            v = evaluate(control, tlist[1])
+            if !(v isa Float64)
                 quiet ||
-                    @error "$(px)`get_parameters(control)` must return a vector of Float64, not $(typeof(parameters))"
+                    @error "$(px)`evaluate(control, t)` must return a Float64, not $(typeof(v))"
                 success = false
             end
         catch exc
             quiet || @error(
-                "$(px)`get_parameters(control)` must return a vector of Float64.",
+                "$(px)`evaluate(control, t)` must be defined.",
                 exception = (exc, catch_abbreviated_backtrace())
             )
             success = false
         end
-    catch exc
-        quiet || @error(
-            "$(px)`get_parameters(control)` must be defined.",
-            exception = (exc, catch_abbreviated_backtrace())
-        )
-        success = false
+        try
+            v₀ = rand()
+            v = evaluate(control, tlist[1]; vals_dict=IdDict(control => v₀))
+            if v != v₀
+                msg = "$(px)`evaluate(control, t; vals_dict=IdDict(control => v))` must return `v`"
+                quiet || @error msg v = v₀ result = v
+                success = false
+            end
+        catch exc
+            quiet || @error(
+                "$(px)`evaluate(control, t; vals_dict=IdDict(control => v))`  must be defined.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
+            success = false
+        end
     end
 
-    try
-        a = discretize(control, tlist)
-        if !(a isa Vector{Float64})
-            quiet ||
-                @error "$(px)`discretize(control, tlist)` must return a Vector{Float64}, not $(typeof(a))"
-            success = false
-        end
-        if !(length(a) == length(tlist))
-            quiet ||
-                @error "$(px)`discretize(control, tlist)` must return a vector of the same size as `tlist` ($(length(a)) ≠ $(length(tlist)))"
-            success = false
-        end
-        a = discretize(control, tlist)
-        if !all(isfinite.(a))
-            quiet ||
-                @error "$(px) all values in `discretize(control, tlist)` must be finite"
-            success = false
-        end
-    catch exc
-        quiet || @error(
-            "$(px)`discretize(control, tlist)` must be defined.",
-            exception = (exc, catch_abbreviated_backtrace())
-        )
-        success = false
-    end
+    if length(tlist) > 2
 
-    try
-        a = discretize_on_midpoints(control, tlist)
-        if !(a isa Vector{Float64})
-            quiet ||
-                @error "$(px)`discretize_on_midpoints(control, tlist)` must return a Vector{Float64}, not $(typeof(a))"
+        try
+            a = discretize(control, tlist)
+            if !(a isa Vector{Float64})
+                quiet ||
+                    @error "$(px)`discretize(control, tlist)` must return a Vector{Float64}, not $(typeof(a))"
+                success = false
+            end
+            if !(length(a) == length(tlist))
+                quiet ||
+                    @error "$(px)`discretize(control, tlist)` must return a vector of the same size as `tlist` ($(length(a)) ≠ $(length(tlist)))"
+                success = false
+            end
+            a = discretize(control, tlist)
+            if !all(isfinite.(a))
+                quiet ||
+                    @error "$(px) all values in `discretize(control, tlist)` must be finite"
+                success = false
+            end
+        catch exc
+            quiet || @error(
+                "$(px)`discretize(control, tlist)` must be defined.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
             success = false
         end
-        if length(a) ≠ length(tlist) - 1
-            quiet ||
-                @error "$(px)`discretize_on_midpoints(control, tlist)` must return a vector of length one less than `tlist` ($(length(a)) ≠ $(length(tlist))-1)"
+
+        try
+            a = discretize_on_midpoints(control, tlist)
+            if !(a isa Vector{Float64})
+                quiet ||
+                    @error "$(px)`discretize_on_midpoints(control, tlist)` must return a Vector{Float64}, not $(typeof(a))"
+                success = false
+            end
+            if length(a) ≠ length(tlist) - 1
+                quiet ||
+                    @error "$(px)`discretize_on_midpoints(control, tlist)` must return a vector of length one less than `tlist` ($(length(a)) ≠ $(length(tlist))-1)"
+                success = false
+            end
+            if !all(isfinite.(a))
+                quiet ||
+                    @error "$(px)all values in `discretize_on_midpoints(control, tlist)` must be finite"
+                success = false
+            end
+        catch exc
+            quiet || @error(
+                "$(px)`discretize_on_midpoints(control, tlist)` must be defined.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
             success = false
         end
-        if !all(isfinite.(a))
-            quiet ||
-                @error "$(px)all values in `discretize_on_midpoints(control, tlist)` must be finite"
-            success = false
-        end
-    catch exc
-        quiet || @error(
-            "$(px)`discretize_on_midpoints(control, tlist)` must be defined.",
-            exception = (exc, catch_abbreviated_backtrace())
-        )
-        success = false
+
     end
 
     return success

--- a/src/interfaces/parameterization.jl
+++ b/src/interfaces/parameterization.jl
@@ -1,0 +1,155 @@
+using ..Controls: get_parameters, ParameterizedFunction
+using LinearAlgebra: norm
+
+
+"""Check a [`ParameterizedFunction`](@ref) instance.
+
+```julia
+@test check_parameterized_function(f; tlist; quiet=false)
+```
+
+verifies that the given `f`:
+
+* is an instance of [`ParameterizedFunction`](@ref).
+* has a field `parameters` that is an `AbstractVector{Float64}`.
+* is a [callable](@extref Julia Function-like-objects) as `f(t)` for values of
+  `t` in `tlist`, returning a `Float64`.
+* [`get_parameters`](@ref) provides access to the `parameters` field.
+* passes [`check_parameterized`](@ref)
+
+# See also
+
+* [`check_parameterized`](@ref) for objects that have parameters
+  ([`get_parameters`](@ref)), but are not instances of
+  [`ParameterizedFunction`](@ref)
+"""
+function check_parameterized_function(
+    f;
+    tlist,
+    quiet=false,
+    _message_prefix="",  # for recursive calling
+)
+    px = _message_prefix
+    success = true
+
+    if !(f isa ParameterizedFunction)
+        quiet || @error "$(px)`f` must be an instance of ParameterizedFunction"
+        success = false
+    end
+
+    if !hasfield(typeof(f), :parameters)
+        quiet || @error "$(px)`f` must have a `parameters` field"
+        success = false
+    end
+
+    try
+        success &= (get_parameters(f) === getfield(f, :parameters))
+        success &= check_parameterized(f)
+    catch exc
+        quiet || @error(
+            "$(px)`get_parameters(f)` must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
+        success = false
+    end
+
+    try
+        t = tlist[begin]
+        v = f(t)
+        if !(v isa Float64)
+            quiet || @error "$(px)`f(t)` must return a Float64, not $(typeof(v))"
+            success = false
+        end
+    catch exc
+        quiet || @error(
+            "$(px)`f(t)` must be defined for t=$t.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
+        success = false
+    end
+
+    return success
+
+end
+
+
+@doc raw"""
+Check that that the object supports the parameterization interface.
+
+```julia
+@test check_parameterized(object; name="::$typeof(object))", quiet=false)
+```
+
+verifies that the given `object`:
+
+* can be passed to [`get_parameters`](@ref), which must return an
+  `AbstractVector` of `Float64`
+* is mutated by mutating the `parameters` obtained by `get_parameters`
+
+# See also
+
+* [`check_parameterized_function`](@ref) is `object` is a
+  [`ParameterizedFunction`](@ref)
+"""
+function check_parameterized(
+    object;
+    name="::$(typeof(object))",
+    quiet=false,
+    _message_prefix="",  # for recursive calling
+)
+    px = _message_prefix
+    success = true
+
+    try
+        parameters = get_parameters(object)
+        try
+            # we only check `eltype` to allow for AbstractVector
+            if !(eltype(parameters) == Float64)
+                quiet ||
+                    @error "$(px)`get_parameters($name)` must return a vector of Float64, not $(typeof(parameters))"
+                success = false
+            end
+        catch exc
+            quiet || @error(
+                "$(px)`get_parameters($name)` must return a vector of Float64.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
+            success = false
+        end
+    catch exc
+        quiet || @error(
+            "$(px)`get_parameters($name)` must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
+        success = false
+    end
+
+    if success && !isempty(get_parameters(object))
+        parameters = get_parameters(object)
+        orig_parameters = copy(Array(parameters))
+        try
+            parameters .= 1.0
+            if !all(isone, get_parameters(object))
+                quiet ||
+                    @error "$(px)writing to the array returned by `get_parameters($name)` must mutate the the controls inside the object"
+                success = false
+            end
+            copyto!(parameters, orig_parameters)
+            Δ = norm(get_parameters(object) - orig_parameters)
+            if Δ > 1e-12
+                msg = "$(px)`copyto!` the array returned by `get_parameters($name)` must mutate the controls inside the object"
+                quiet || @error msg get_parameters(object) orig_parameters Δ
+                success = false
+            end
+        catch exc
+            quiet || @error(
+                "$(px)Cannot mutate `get_parameters($name)`.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
+            success = false
+        end
+    end
+
+    return success
+
+end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
@@ -25,6 +26,7 @@ QuantumControlTestUtils = "d3fd27c9-1dfb-4e67-b0c0-90d0d87a1e48"
 QuantumGradientGenerators = "a563f35e-61db-434d-8c01-8b9e3ccdfd85"
 QuantumPropagators = "7bf12567-5742-4b91-a078-644e72a65fc1"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -34,6 +36,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 TwoQubitWeylChamber = "cad078a0-0012-46f4-b55e-a945d44e115b"
+UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,6 +43,11 @@ using SafeTestsets
         include("test_amplitudes.jl")
     end
 
+    println("\n* Parameterization (test_parameterization.jl):")
+    @time @safetestset "Parameterization" begin
+        include("test_parameterization.jl")
+    end
+
     println("\n* Discretization (test_discretization.jl):")
     @time @safetestset "Discretization" begin
         include("test_discretization.jl")

--- a/test/test_hamiltonian.jl
+++ b/test/test_hamiltonian.jl
@@ -100,7 +100,7 @@ end
     Ψ = random_state_vector(5)
     tlist = collect(range(0, 2; length=20))
     @test check_state(Ψ; normalized=true)
-    @test check_generator(H; state=Ψ, tlist)
+    @test check_generator(H; state=Ψ, tlist, for_parameterization=true)
 end
 
 

--- a/test/test_parameterization.jl
+++ b/test/test_parameterization.jl
@@ -1,0 +1,219 @@
+using Test
+using ComponentArrays
+using RecursiveArrayTools  # to ensure extension is loaded
+using UnPack: @unpack
+using QuantumPropagators: hamiltonian
+using QuantumPropagators.Controls: ParameterizedFunction, get_parameters, get_controls
+using QuantumPropagators.Interfaces: check_parameterized_function
+using QuantumPropagators.Interfaces: check_parameterized
+using QuantumPropagators.Interfaces: check_generator
+
+struct GaussianControl <: ParameterizedFunction
+    parameters::ComponentVector{Float64,Vector{Float64},Tuple{Axis{(A=1, t₀=2, σ=3)}}}
+    GaussianControl(; kwargs...) = new(ComponentVector(; kwargs...))
+end
+
+function (control::GaussianControl)(t)
+    @unpack A, t₀, σ = control.parameters
+    return A * exp(-(t - t₀)^2 / (2 * σ^2))
+end
+
+
+const 𝕚 = 1im
+
+
+function total_enantiomer_ham(parameters; sign, a, independent_parameters=false, kwargs...)
+
+    μ = (sign == "-" ? -1 : 1)
+    H₁Re = μ * ComplexF64[0 1 0; 1 0 0; 0  0 0]
+    H₁Im = μ * ComplexF64[0 𝕚 0; -𝕚 0 0; 0  0 0]
+    H₂Re = μ * ComplexF64[0 0 0; 0 0 1; 0  1 0]
+    H₂Im = μ * ComplexF64[0 0 0; 0 0 𝕚; 0 -𝕚 0]
+    H₃Re = μ * ComplexF64[0 0 1; 0 0 0; 1  0 0]
+    H₃Im = μ * ComplexF64[0 0 𝕚; 0 0 0; -𝕚  0 0]
+
+    if independent_parameters
+        # This doesn't make sense physically, but it's a good way to test
+        # collecting multiple parameter arrays
+        return hamiltonian(
+            (H₁Re, TEH_field1Re(copy(parameters), a)),
+            (H₁Im, TEH_field1Im(copy(parameters), a)),
+            (H₂Re, TEH_field2Re(copy(parameters), a)),
+            (H₂Im, TEH_field2Im(copy(parameters), a)),
+            (H₃Re, TEH_field3Re(copy(parameters), a)),
+            (H₃Im, TEH_field3Im(copy(parameters), a));
+            kwargs...
+        )
+    else
+        return hamiltonian(
+            (H₁Re, TEH_field1Re(parameters, a)),
+            (H₁Im, TEH_field1Im(parameters, a)),
+            (H₂Re, TEH_field2Re(parameters, a)),
+            (H₂Im, TEH_field2Im(parameters, a)),
+            (H₃Re, TEH_field3Re(parameters, a)),
+            (H₃Im, TEH_field3Im(parameters, a));
+            kwargs...
+        )
+    end
+
+end
+
+struct TEH_field1Re <: ParameterizedFunction
+    parameters::ComponentVector{
+        Float64,
+        Vector{Float64},
+        Tuple{Axis{(ΔT₁=1, ΔT₂=2, ΔT₃=3, ϕ₁=4, ϕ₂=5, ϕ₃=6, E₀₁=7, E₀₂=8, E₀₃=9)}}
+    }
+    a::Float64
+end
+
+function (E::TEH_field1Re)(t)
+    @unpack E₀₁, ΔT₁, ϕ₁ = E.parameters
+    _tanhfield(t; E₀=E₀₁, t₁=0.0, t₂=ΔT₁, a=E.a) * cos(ϕ₁)
+end
+
+struct TEH_field2Re <: ParameterizedFunction
+    parameters::ComponentVector{
+        Float64,
+        Vector{Float64},
+        Tuple{Axis{(ΔT₁=1, ΔT₂=2, ΔT₃=3, ϕ₁=4, ϕ₂=5, ϕ₃=6, E₀₁=7, E₀₂=8, E₀₃=9)}}
+    }
+    a::Float64
+end
+
+function (E::TEH_field2Re)(t)
+    @unpack E₀₂, ΔT₁, ΔT₂, ϕ₂ = E.parameters
+    _tanhfield(t; E₀=E₀₂, t₁=ΔT₁, t₂=(ΔT₁ + ΔT₂), a=E.a) * cos(ϕ₂)
+end
+
+struct TEH_field3Re <: ParameterizedFunction
+    parameters::ComponentVector{
+        Float64,
+        Vector{Float64},
+        Tuple{Axis{(ΔT₁=1, ΔT₂=2, ΔT₃=3, ϕ₁=4, ϕ₂=5, ϕ₃=6, E₀₁=7, E₀₂=8, E₀₃=9)}}
+    }
+    a::Float64
+end
+
+function (E::TEH_field3Re)(t)
+    @unpack E₀₃, ΔT₁, ΔT₂, ΔT₃, ϕ₃ = E.parameters
+    _tanhfield(t; E₀=E₀₃, t₁=(ΔT₁ + ΔT₂), t₂=(ΔT₁ + ΔT₂ + ΔT₃), a=E.a) * cos(ϕ₃)
+end
+
+struct TEH_field1Im <: ParameterizedFunction
+    parameters::ComponentVector{
+        Float64,
+        Vector{Float64},
+        Tuple{Axis{(ΔT₁=1, ΔT₂=2, ΔT₃=3, ϕ₁=4, ϕ₂=5, ϕ₃=6, E₀₁=7, E₀₂=8, E₀₃=9)}}
+    }
+    a::Float64
+end
+
+function (E::TEH_field1Im)(t)
+    @unpack E₀₁, ΔT₁, ϕ₁ = E.parameters
+    _tanhfield(t; E₀=E₀₁, t₁=0.0, t₂=ΔT₁, a=E.a) * sin(ϕ₁)
+end
+
+struct TEH_field2Im <: ParameterizedFunction
+    parameters::ComponentVector{
+        Float64,
+        Vector{Float64},
+        Tuple{Axis{(ΔT₁=1, ΔT₂=2, ΔT₃=3, ϕ₁=4, ϕ₂=5, ϕ₃=6, E₀₁=7, E₀₂=8, E₀₃=9)}}
+    }
+    a::Float64
+end
+
+function (E::TEH_field2Im)(t)
+    @unpack E₀₂, ΔT₁, ΔT₂, ϕ₂ = E.parameters
+    _tanhfield(t; E₀=E₀₂, t₁=ΔT₁, t₂=(ΔT₁ + ΔT₂), a=E.a) * sin(ϕ₂)
+end
+
+struct TEH_field3Im <: ParameterizedFunction
+    parameters::ComponentVector{
+        Float64,
+        Vector{Float64},
+        Tuple{Axis{(ΔT₁=1, ΔT₂=2, ΔT₃=3, ϕ₁=4, ϕ₂=5, ϕ₃=6, E₀₁=7, E₀₂=8, E₀₃=9)}}
+    }
+    a::Float64
+end
+
+function (E::TEH_field3Im)(t)
+    @unpack E₀₃, ΔT₁, ΔT₂, ΔT₃, ϕ₃ = E.parameters
+    _tanhfield(t; E₀=E₀₃, t₁=(ΔT₁ + ΔT₂), t₂=(ΔT₁ + ΔT₂ + ΔT₃), a=E.a) * sin(ϕ₃)
+end
+
+_tanhfield(t; E₀, t₁, t₂, a) = (E₀ / 2) * (tanh(a * (t - t₁)) - tanh(a * (t - t₂)));
+
+
+@testset "get_parameters of controls" begin
+
+    ϵ(t) = 1.0
+    p = get_parameters(ϵ)
+    @test isempty(p)
+    @test check_parameterized(ϵ)
+
+    ϵ = [0.0, 1.0, 0.0]
+    p = get_parameters(ϵ)
+    @test isempty(p)
+    @test check_parameterized(ϵ)
+
+    gaussian = GaussianControl(A=1.0, t₀=0.5, σ=0.2)
+    p = get_parameters(gaussian)
+    @test p isa AbstractVector
+    @test eltype(p) == Float64
+    @test length(p) == 3
+    @test Array(p) == [1.0, 0.5, 0.2]
+    @test check_parameterized_function(gaussian; tlist=[0.0, 1.0])
+
+end
+
+
+@testset "enantiomer_ham" begin
+
+    parameters = ComponentVector(
+        ΔT₁=0.3,
+        ΔT₂=0.4,
+        ΔT₃=0.3,
+        ϕ₁=0.0,
+        ϕ₂=0.0,
+        ϕ₃=0.0,
+        E₀₁=4.5,
+        E₀₂=4.0,
+        E₀₃=5.0
+    )
+    ϵ = TEH_field1Re(parameters, 100.0)
+    tlist = [0.0, 0.5, 1.0]
+    @test check_parameterized_function(ϵ; tlist)
+    H = total_enantiomer_ham(parameters; sign="+", a=100)
+    @test length(get_controls(H)) == 6
+    Ψ₀ = ComplexF64[1, 0, 0]
+    @test check_generator(H; state=Ψ₀, tlist, for_parameterization=true)
+    @test check_parameterized(H)
+    @test get_parameters(H) === parameters
+
+end
+
+
+@testset "enantiomer_ham - collect independent parameters" begin
+
+    parameters = ComponentVector(
+        ΔT₁=0.3,
+        ΔT₂=0.4,
+        ΔT₃=0.3,
+        ϕ₁=0.0,
+        ϕ₂=0.0,
+        ϕ₃=0.0,
+        E₀₁=4.5,
+        E₀₂=4.0,
+        E₀₃=5.0
+    )
+    H = total_enantiomer_ham(parameters; independent_parameters=true, sign="+", a=100)
+    @test length(get_controls(H)) == 6
+    Ψ₀ = ComplexF64[1, 0, 0]
+    tlist = [0.0, 0.5, 1.0]
+    @test check_generator(H; state=Ψ₀, tlist, for_parameterization=true)
+    @test check_parameterized(H)
+    p = get_parameters(H)
+    @test length(p) == length(get_controls(H)) * length(parameters)
+
+end


### PR DESCRIPTION
Extend `get_parameters` to arbitrary objects, where parameters are collected into a `RecursiveArrayTools.ArrayPartition`.

Extend the interface definitions to account for parameters.

`ComponentArrays` are now the recommended way to define arrays of parameters.