### PR TITLE
Properly define the in-place vs not-in-place interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,17 +11,18 @@ ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [weakdeps]
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [extensions]
 QuantumPropagatorsODEExt = "OrdinaryDiffEq"
 QuantumPropagatorsRecursiveArrayToolsExt = "RecursiveArrayTools"
+QuantumPropagatorsStaticArraysExt = "StaticArrays"
 
 [compat]
 OffsetArrays = "1"

--- a/ext/QuantumPropagatorsODEExt.jl
+++ b/ext/QuantumPropagatorsODEExt.jl
@@ -12,6 +12,7 @@ using QuantumPropagators:
     ode_function
 using QuantumPropagators.Controls:
     get_controls, get_parameters, evaluate, evaluate!, discretize_on_midpoints
+using QuantumPropagators.Interfaces: supports_inplace
 import QuantumPropagators: init_prop, reinit_prop!, prop_step!, set_state!, set_t!
 
 
@@ -24,7 +25,7 @@ ode_propagator = init_prop(
     generator,
     tlist;
     method=OrdinaryDiffEq,  # or: `method=DifferentialEquations`
-    inplace=true,
+    inplace=QuantumPropagators.Interfaces.supports_inplace(state),
     backward=false,
     verbose=false,
     parameters=nothing,
@@ -92,7 +93,7 @@ function init_prop(
     generator,
     tlist,
     method::Val{:OrdinaryDiffEq};
-    inplace=true,
+    inplace=supports_inplace(state),
     backward=false,
     verbose=false,
     parameters=nothing,

--- a/ext/QuantumPropagatorsStaticArraysExt.jl
+++ b/ext/QuantumPropagatorsStaticArraysExt.jl
@@ -1,0 +1,9 @@
+module QuantumPropagatorsStaticArraysExt
+
+import QuantumPropagators.Interfaces: supports_inplace
+using StaticArrays: SArray, MArray
+
+supports_inplace(::SArray) = false
+supports_inplace(::MArray) = true
+
+end

--- a/src/QuantumPropagators.jl
+++ b/src/QuantumPropagators.jl
@@ -34,6 +34,25 @@ include("propagator.jl")
 export init_prop, reinit_prop!, prop_step!
 # not exported: set_t!, set_state!
 
+#! format: off
+module Interfaces
+    export supports_inplace
+    export check_operator, check_state, check_tlist, check_amplitude
+    export check_control, check_generator, check_propagator
+    export check_parameterized_function, check_parameterized
+    include("interfaces/supports_inplace.jl")
+    include("interfaces/utils.jl")
+    include("interfaces/state.jl")
+    include("interfaces/tlist.jl")
+    include("interfaces/operator.jl")
+    include("interfaces/amplitude.jl")
+    include("interfaces/control.jl")
+    include("interfaces/generator.jl")
+    include("interfaces/propagator.jl")
+    include("interfaces/parameterization.jl")
+end
+#! format: on
+
 include("pwc_utils.jl")
 include("cheby_propagator.jl")
 include("newton_propagator.jl")
@@ -41,22 +60,6 @@ include("exp_propagator.jl")
 
 include("ode_function.jl")
 
-#! format: off
-module Interfaces
-    export check_operator, check_state, check_tlist, check_amplitude
-    export check_control, check_generator, check_propagator
-    export check_parameterized_function, check_parameterized
-    include(joinpath("interfaces", "utils.jl"))
-    include(joinpath("interfaces", "state.jl"))
-    include(joinpath("interfaces", "tlist.jl"))
-    include(joinpath("interfaces", "operator.jl"))
-    include(joinpath("interfaces", "amplitude.jl"))
-    include(joinpath("interfaces", "control.jl"))
-    include(joinpath("interfaces", "generator.jl"))
-    include(joinpath("interfaces", "propagator.jl"))
-    include(joinpath("interfaces", "parameterization.jl"))
-end
-#! format: on
 
 include("timings.jl")
 

--- a/src/expprop.jl
+++ b/src/expprop.jl
@@ -4,7 +4,6 @@ module ExpProp
 export ExpPropWrk, expprop!
 
 using LinearAlgebra
-import StaticArrays
 using TimerOutputs: @timeit_debug, TimerOutput
 
 

--- a/src/generators.jl
+++ b/src/generators.jl
@@ -102,7 +102,11 @@ constant `Number`. If the number of coefficients is less than the
 number of operators, the first `ops` are considered to have ``c_l = 1``.
 
 An `Operator` object would generally not be instantiated directly, but be
-obtained from a (@ref) via [`evaluate`](@ref).
+obtained from a [`Generator`](@ref) via [`evaluate`](@ref).
+
+The ``Ĥ_l`` in the sum are considered immutable. This implies that an
+`Operator` can be updated in-place with [`evaluate!`](@ref) by only changing
+the `coeffs`.
 """
 struct Operator{OT,CT<:Number}
 

--- a/src/interfaces/state.jl
+++ b/src/interfaces/state.jl
@@ -6,39 +6,44 @@ using LinearAlgebra
 """Check that `state` is a valid element of a Hilbert space.
 
 ```julia
-@test check_state(state;
-                  for_immutable_state=true, for_mutable_state=true,
-                  normalized=false, atol=1e-15, quiet=false)
+@test check_state(state; normalized=false, atol=1e-15, quiet=false)
 ```
 
 verifies the following requirements:
 
 * The inner product (`LinearAlgebra.dot`) of two states must return a Complex
-  number type.
+  number.
 * The `LinearAlgebra.norm` of `state` must be defined via the inner product.
-  This is the *definition* of a Hilbert space, a.k.a a complete inner product
-  space or more precisely a Banach space (normed vector space) where the
-  norm is induced by an inner product.
+  This is the *definition* of a Hilbert space, a.k.a a "complete inner product
+  space" or more precisely a "Banach space (normed vector space) where the
+  norm is induced by an inner product".
+* The [`QuantumPropagators.Interfaces.supports_inplace](@ref) method must be
+  defined for `state`
 
-If `for_immutable_state`:
+Any `state` must support the following not-in-place operations:
 
 * `state + state` and `state - state` must be defined
-* `copy(state)` must be defined
+* `copy(state)` must be defined and return an object of the same type as
+  `state`
 * `c * state` for a scalar `c` must be defined
 * `norm(state + state)` must fulfill the triangle inequality
+* `zero(state)` must be defined and produce a state with norm 0
 * `0.0 * state` must produce a state with norm 0
 * `copy(state) - state` must have norm 0
 * `norm(state)` must have absolute homogeneity: `norm(s * state) = s *
   norm(state)`
 
-If `for_mutable_state`:
+If `supports_inplace(state)` is `true`, the `state` must also support the
+following:
 
-* `similar(state)` must be defined and return a valid state
+* `similar(state)` must be defined and return a valid state of the same type a
+  `state`
 * `copyto!(other, state)` must be defined
+* `fill!(state, c)` must be defined
 * `LinearAlgebra.lmul!(c, state)` for a scalar `c` must be defined
 * `LinearAlgebra.axpy!(c, state, other)` must be defined
 * `norm(state)` must fulfill the same general mathematical norm properties as
-  with `for_immutable_state`.
+  for the non-in-place norm.
 
 If `normalized` (not required by default):
 
@@ -53,8 +58,6 @@ failed.
 """
 function check_state(
     state;
-    for_immutable_state=true,
-    for_mutable_state=true,
     normalized=false,
     atol=1e-14,
     quiet=false,
@@ -66,6 +69,17 @@ function check_state(
     px = _message_prefix
 
     success = true
+    inplace = false
+
+    try
+        inplace = supports_inplace(state)
+    catch exc
+        quiet || @error(
+            "$(px)The `QuantumPropagators.Interfaces.supports_inplace` method must be defined for `state`.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
+        success = false
+    end
 
     try
         c = state ⋅ state
@@ -98,78 +112,100 @@ function check_state(
         success = false
     end
 
-    if for_immutable_state
+    # not-in-place interface:
 
-        try
-            Δ = norm(state - state)
-            if Δ > atol
-                quiet || @error "`$(px)state - state` must have norm 0"
-                success = false
-            end
-            η = norm(state + state)
-            if η > (2 * norm(state) + atol)
-                quiet ||
-                    @error "`$(px)norm(state + state)` must fulfill the triangle inequality"
-                success = false
-            end
-        catch exc
-            quiet || @error(
-                "$(px)`state + state` and `state - state` must be defined.",
-                exception = (exc, catch_abbreviated_backtrace())
-            )
+    try
+        Δ = norm(state - state)
+        if Δ > atol
+            quiet || @error "`$(px)state - state` must have norm 0"
             success = false
         end
-
-        try
-            ϕ = copy(state)
-            if norm(ϕ - state) > atol
-                quiet || @error "$(px)`copy(state) - state` must have norm 0"
-                success = false
-            end
-        catch exc
-            quiet || @error(
-                "$(px)copy(state) must be defined.",
-                exception = (exc, catch_abbreviated_backtrace())
-            )
+        η = norm(state + state)
+        if η > (2 * norm(state) + atol)
+            quiet ||
+                @error "`$(px)norm(state + state)` must fulfill the triangle inequality"
             success = false
         end
-
-        try
-            ϕ = 0.5 * state
-            if abs(norm(ϕ) - 0.5 * norm(state)) > atol
-                quiet ||
-                    @error "$(px)`norm(state)` must have absolute homogeneity: `norm(s * state) = s * norm(state)`"
-                success = false
-            end
-        catch exc
-            quiet || @error(
-                "$(px)`c * state` for a scalar `c` must be defined.",
-                exception = (exc, catch_abbreviated_backtrace())
-            )
-            success = false
-        end
-
-        try
-            if norm(0.0 * state) > atol
-                quiet || @error "$(px)`0.0 * state` must produce a state with norm 0"
-                success = false
-            end
-        catch exc
-            quiet || @error(
-                "$(px)`0.0 * state` must produce a state with norm 0.",
-                exception = (exc, catch_abbreviated_backtrace())
-            )
-            success = false
-        end
-
+    catch exc
+        quiet || @error(
+            "$(px)`state + state` and `state - state` must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
+        success = false
     end
 
-    if for_mutable_state
+    try
+        ϕ = copy(state)
+        if typeof(ϕ) != typeof(state)
+            quiet ||
+                @error "$(px)`copy(state)::$(typeof(ϕ))` must have the same type as `state::$(typeof(state))`"
+            success = false
+        end
+        if norm(ϕ - state) > atol
+            quiet || @error "$(px)`copy(state) - state` must have norm 0"
+            success = false
+        end
+    catch exc
+        quiet || @error(
+            "$(px)copy(state) must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
+        success = false
+    end
+
+    try
+        ϕ = 0.5 * state
+        if abs(norm(ϕ) - 0.5 * norm(state)) > atol
+            quiet ||
+                @error "$(px)`norm(state)` must have absolute homogeneity: `norm(s * state) = s * norm(state)`"
+            success = false
+        end
+    catch exc
+        quiet || @error(
+            "$(px)`c * state` for a scalar `c` must be defined.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
+        success = false
+    end
+
+    try
+        state_zero = zero(state)
+        if norm(state_zero) > atol
+            quiet || @error("$(px)`zero(state)` must produce a state with norm 0.")
+        end
+    catch exc
+        quiet || @error(
+            "$(px)`zero(state)` must be defined and produce a state with norm 0.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
+        success = false
+    end
+
+    try
+        if norm(0.0 * state) > atol
+            quiet || @error "$(px)`0.0 * state` must produce a state with norm 0"
+            success = false
+        end
+    catch exc
+        quiet || @error(
+            "$(px)`0.0 * state` must produce a state with norm 0.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
+        success = false
+    end
+
+
+    if inplace
 
         has_similar = true
         similar_is_valid = true
         try
             ϕ = similar(state)
+            if typeof(ϕ) != typeof(state)
+                quiet ||
+                    @error "$(px)`similar(state)::$(typeof(ϕ))` must have the same type as `state::$(typeof(state))`"
+                success = false
+            end
         catch exc
             quiet || @error(
                 "$(px)`similar(state)` must be defined.",
@@ -189,8 +225,6 @@ function check_state(
                     # the checks
                     if !check_state(
                         ϕ;
-                        for_immutable_state,
-                        for_mutable_state,
                         normalized=false,
                         atol,
                         _check_similar=false,
@@ -202,12 +236,10 @@ function check_state(
                         success = false
                     end
                 end
-                if for_immutable_state
-                    if norm(ϕ - state) > atol
-                        quiet ||
-                            @error "$(px)`ϕ - state` must have norm 0, where `ϕ = similar(state); copyto!(ϕ, state)`"
-                        success = false
-                    end
+                if norm(ϕ - state) > atol
+                    quiet ||
+                        @error "$(px)`ϕ - state` must have norm 0, where `ϕ = similar(state); copyto!(ϕ, state)`"
+                    success = false
                 end
             end
         catch exc
@@ -222,13 +254,33 @@ function check_state(
             if has_similar && similar_is_valid
                 ϕ = similar(state)
                 copyto!(ϕ, state)
+                state_zero = fill!(ϕ, 0.0)
+                if !isa(state_zero, typeof(ϕ))
+                    quiet || @error "$(px)`fill!(state, 0.0)` must return the filled state"
+                    success = false
+                end
+                if norm(state_zero) > atol
+                    quiet || @error "$(px)`fill!(state, 0.0)` must have norm 0"
+                    success = false
+                end
+            end
+        catch exc
+            quiet || @error(
+                "$(px)`fill!(state, c)` must be defined.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
+            success = false
+        end
+
+        try
+            if has_similar && similar_is_valid
+                ϕ = similar(state)
+                copyto!(ϕ, state)
                 ϕ = lmul!(1im, ϕ)
-                if for_immutable_state
-                    if norm(ϕ - 1im * state) > atol
-                        quiet ||
-                            @error "$(px)`norm(state)` must have absolute homogeneity: `norm(s * state) = s * norm(state)`"
-                        success = false
-                    end
+                if norm(ϕ - 1im * state) > atol
+                    quiet ||
+                        @error "$(px)`norm(state)` must have absolute homogeneity: `norm(s * state) = s * norm(state)`"
+                    success = false
                 end
             end
         catch exc
@@ -263,12 +315,9 @@ function check_state(
                 ϕ = similar(state)
                 copyto!(ϕ, state)
                 ϕ = axpy!(1im, state, ϕ)
-                if for_immutable_state
-                    if norm(ϕ - (state + 1im * state)) > atol
-                        quiet ||
-                            @error "$(px)`axpy!(a, state, ϕ)` must match `ϕ += a * state`"
-                        success = false
-                    end
+                if norm(ϕ - (state + 1im * state)) > atol
+                    quiet || @error "$(px)`axpy!(a, state, ϕ)` must match `ϕ += a * state`"
+                    success = false
                 end
             end
         catch exc
@@ -279,7 +328,7 @@ function check_state(
             success = false
         end
 
-    end
+    end  # in-place interface
 
     if normalized
         try

--- a/src/interfaces/supports_inplace.jl
+++ b/src/interfaces/supports_inplace.jl
@@ -1,0 +1,41 @@
+import ..Operator
+import ..ScaledOperator
+import LinearAlgebra
+
+"""Indicate whether a given state or operator supports in-place operations
+
+```julia
+supports_inplace(state)
+```
+
+Indicates that propagators can assume that the in-place requirements defined
+in [`QuantumPropagators.Interfaces.check_state`](@ref) hold. States with
+in-place support must also fulfill specific properties when interacting with
+operators, see [`QuantumPropagators.Interfaces.check_operator`](@ref).
+
+```julia
+supports_inplace(op)
+```
+
+Indicates that the operator can be evaluated in-place with [`evaluate!`](@ref),
+see [`QuantumPropagators.Interfaces.check_generator`](@ref)
+
+Note that `supports_inplace` is not quite the same as
+[`Base.ismutable`](@extref): When using [custom structs](@extref Julia
+:label:`Mutable-Composite-Types`) for states or operators, even if those
+structs are not defined as `mutable`, they may still define the in-place
+interface (typically because their *components* are mutable).
+"""
+supports_inplace(state::Vector{ComplexF64}) = true
+supports_inplace(state::AbstractVector) = ismutable(state)  # fallback
+# The fallback doesn't actually guarantee that the required interface implied
+# by `supports_inplace` is fulfilled, but it's a reasonable expectation to
+# have, and the `check_state` function will test it.
+
+supports_inplace(op::Matrix) = true
+supports_inplace(op::Operator) = true
+supports_inplace(op::LinearAlgebra.Diagonal) = true
+supports_inplace(op::ScaledOperator) = supports_inplace(op.operator)
+supports_inplace(op::AbstractMatrix) = ismutable(op)  # fallback
+
+# Note: methods for StaticArrays are defined in package extension

--- a/src/ode_function.jl
+++ b/src/ode_function.jl
@@ -1,3 +1,4 @@
+using QuantumPropagators.Interfaces: supports_inplace
 using TimerOutputs: @timeit_debug, TimerOutput
 
 @doc raw"""
@@ -65,10 +66,14 @@ end
 
 function (f::QuantumODEFunction)(du, u, p, t)
     @timeit_debug f.timing_data "operator evaluation" begin
-        evaluate!(f.operator, f.generator, t; vals_dict=p)
+        if supports_inplace(f.operator)
+            H = evaluate!(f.operator, f.generator, t; vals_dict=p)
+        else
+            H = evaluate(f.generator, t; vals_dict=p)
+        end
     end
     @timeit_debug f.timing_data "matrix-vector product" begin
-        return mul!(du, f.operator, u, f.c, false)
+        return mul!(du, H, u, f.c, false)
     end
 end
 

--- a/src/propagator.jl
+++ b/src/propagator.jl
@@ -133,7 +133,7 @@ propagator = init_prop(
     state, generator, tlist;
     method,  # mandatory keyword argument
     backward=false,
-    inplace=true,
+    inplace=QuantumPropagators.Interfaces.supports_inplace(state),
     piecewise=nothing,
     pwc=nothing,
     kwargs...
@@ -172,8 +172,8 @@ time grid `tlist` under the time-dependent generator (Hamiltonian/Liouvillian)
   call to [`prop_step!`](@ref) changes the reference for `propagator.state`,
   and the propagation will not use any in-place operations. Not all propagation
   methods may support both in-place and not-in-place propagation. In-place
-  propagation is generally more efficient but may not be compatible, e.g., with
-  automatic differentiation.
+  propagation is generally more efficient for larger Hilbert space dimensions,
+  but may not be compatible, e.g., with automatic differentiation.
 * `piecewise`: If given as a boolean, `true` enforces that the resulting
   propagator is a [`PiecewisePropagator`](@ref), and `false` enforces that it
   not a [`PiecewisePropagator`](@ref). For the default `piecewise=nothing`,
@@ -211,7 +211,7 @@ function init_prop(
     tlist;
     method,  # mandatory keyword argument
     backward=false,
-    inplace=true,
+    inplace=Interfaces.supports_inplace(state),
     verbose=false,
     piecewise=nothing,
     pwc=nothing,

--- a/test/test_invalid_interfaces.jl
+++ b/test/test_invalid_interfaces.jl
@@ -1,10 +1,11 @@
 using Test
 using Logging: with_logger
-using QuantumControlTestUtils: QuantumTestLogger
+using IOCapture: IOCapture
 using QuantumControlTestUtils.RandomObjects: random_dynamic_generator, random_state_vector
 using StableRNGs: StableRNG
-using QuantumPropagators: init_prop
+using QuantumPropagators: QuantumPropagators, init_prop
 using LinearAlgebra
+import QuantumPropagators.Interfaces: supports_inplace
 using QuantumPropagators.Interfaces:
     check_amplitude,
     check_control,
@@ -21,16 +22,16 @@ using QuantumPropagators.Interfaces:
     tlist = collect(range(0, 10, length=101))
 
     ampl = InvalidAmplitude()
-    test_logger = QuantumTestLogger()
-    with_logger(test_logger) do
-        @test check_amplitude(ampl; tlist) ≡ false
+    captured = IOCapture.capture() do
+        check_amplitude(ampl; tlist)
     end
+    @test captured.value ≡ false
 
-    @test "get_controls(ampl)` must be defined" ∈ test_logger
-    @test "all controls in `ampl` must pass `check_control`" ∈ test_logger
-    @test "`substitute(ampl, replacements)` must be defined" ∈ test_logger
-    @test "`evaluate(ampl, tlist, 1)` must return a Number" ∈ test_logger
-    @test "`evaluate(ampl, tlist, n; vals_dict)` must be defined" ∈ test_logger
+    @test contains(captured.output, "get_controls(ampl)` must be defined")
+    @test contains(captured.output, "all controls in `ampl` must pass `check_control`")
+    @test contains(captured.output, "`substitute(ampl, replacements)` must be defined")
+    @test contains(captured.output, "`evaluate(ampl, tlist, 1)` must return a Number")
+    @test contains(captured.output, "`evaluate(ampl, tlist, n; vals_dict)` must be defined")
 
 end
 
@@ -42,23 +43,30 @@ end
     tlist = collect(range(0, 10, length=101))
 
     control = InvalidControl()
-    test_logger = QuantumTestLogger()
-    with_logger(test_logger) do
-        @test check_control(control; tlist) ≡ false
+    captured = IOCapture.capture() do
+        check_control(control; tlist)
     end
-
-    @test "`discretize(control, tlist)` must be defined" ∈ test_logger
-    @test "`discretize_on_midpoints(control, tlist)` must be defined" ∈ test_logger
+    @test captured.value ≡ false
+    @test contains(captured.output, "`discretize(control, tlist)` must be defined")
+    @test contains(
+        captured.output,
+        "`discretize_on_midpoints(control, tlist)` must be defined"
+    )
 
     tlist = [0.0, 1.0, 2.0, 3.0]
     control = [0.0, NaN, Inf, 0.0]
-    test_logger = QuantumTestLogger()
-    with_logger(test_logger) do
-        @test check_control(control; tlist) ≡ false
+    captured = IOCapture.capture() do
+        check_control(control; tlist)
     end
-    @test "all values in `discretize(control, tlist)` must be finite" ∈ test_logger
-    @test "all values in `discretize_on_midpoints(control, tlist)` must be finite" ∈
-          test_logger
+    @test captured.value ≡ false
+    @test contains(
+        captured.output,
+        "all values in `discretize(control, tlist)` must be finite"
+    )
+    @test contains(
+        captured.output,
+        "all values in `discretize_on_midpoints(control, tlist)` must be finite"
+    )
 
 end
 
@@ -71,16 +79,25 @@ end
     tlist = collect(range(0, 10, length=101))
 
     operator = InvalidOperator()
-    test_logger = QuantumTestLogger()
-    with_logger(test_logger) do
-        @test check_operator(operator; state, tlist) ≡ false
+    captured = IOCapture.capture() do
+        check_operator(operator; state, tlist)
     end
-
-    @test "op must not contain any controls" ∈ test_logger
-    @test "`op * state` must be defined" ∈ test_logger
-    @test "The 3-argument `mul!` must apply `op` to the given `state`" ∈ test_logger
-    @test "The 5-argument `mul!` must apply `op` to the given `state`" ∈ test_logger
-    @test "`dot(state, op, state)` must return return a number" ∈ test_logger
+    @test captured.value ≡ false
+    @test contains(
+        captured.output,
+        "The `QuantumPropagators.Interfaces.supports_inplace` method must be defined for `op`"
+    )
+    @test contains(captured.output, "op must not contain any controls")
+    @test contains(captured.output, "`op * state` must be defined")
+    @test contains(
+        captured.output,
+        "The 3-argument `mul!` must apply `op` to the given `state`"
+    )
+    @test contains(
+        captured.output,
+        "The 5-argument `mul!` must apply `op` to the given `state`"
+    )
+    @test contains(captured.output, "`dot(state, op, state)` must return return a number")
 
 end
 
@@ -93,61 +110,82 @@ end
     tlist = collect(range(0, 10, length=101))
 
     generator = InvalidGenerator()
-    test_logger = QuantumTestLogger()
-    with_logger(test_logger) do
-        @test check_generator(generator; state, tlist) ≡ false
+    captured = IOCapture.capture() do
+        check_generator(generator; state, tlist)
     end
+    @test captured.value ≡ false
 
-    @test "`get_controls(generator)` must be defined" ∈ test_logger
-    @test "`evaluate(generator, tlist, n)` must return an operator that passes `check_operator`" ∈
-          test_logger
-    @test "`substitute(generator, replacements)` must be defined" ∈ test_logger
+    @test contains(captured.output, "`get_controls(generator)` must be defined")
+    @test contains(
+        captured.output,
+        "`evaluate(generator, tlist, n)` must return an operator that passes `check_operator`"
+    )
+    @test contains(captured.output, "`substitute(generator, replacements)` must be defined")
 
 end
 
 
 @testset "Invalid state" begin
 
-    struct InvalidState end
-    state = InvalidState()
-    test_logger = QuantumTestLogger()
-    with_logger(test_logger) do
-        @test check_state(state; normalized=true) ≡ false
+    struct InvalidStaticState end
+    state = InvalidStaticState()
+    captured = IOCapture.capture() do
+        check_state(state)
     end
-    @test "`similar(state)` must be defined" ∈ test_logger
-    @test "the inner product of two states must be a complex number" ∈ test_logger
-    @test "the norm of a state must be defined via the inner product" ∈ test_logger
-    @test "`state + state` and `state - state` must be defined" ∈ test_logger
-    @test "copy(state) must be defined" ∈ test_logger
-    @test "`c * state` for a scalar `c` must be defined" ∈ test_logger
-    @test "`0.0 * state` must produce a state with norm 0" ∈ test_logger
-    @test "`norm(state)` must be 1" ∈ test_logger
+    @test captured.value ≡ false
+    @test contains(
+        captured.output,
+        "The `QuantumPropagators.Interfaces.supports_inplace` method must be defined for `state`"
+    )
 
+    struct InvalidState end
+    QuantumPropagators.Interfaces.supports_inplace(::InvalidState) = true
+    state = InvalidState()
+    captured = IOCapture.capture() do
+        check_state(state; normalized=true)
+    end
+    @test captured.value ≡ false
+    @test contains(captured.output, "`similar(state)` must be defined")
+    @test contains(
+        captured.output,
+        "the inner product of two states must be a complex number"
+    )
+    @test contains(
+        captured.output,
+        "the norm of a state must be defined via the inner product"
+    )
+    @test contains(captured.output, "`state + state` and `state - state` must be defined")
+    @test contains(captured.output, "copy(state) must be defined")
+    @test contains(captured.output, "`c * state` for a scalar `c` must be defined")
+    @test contains(captured.output, "`0.0 * state` must produce a state with norm 0")
+    @test contains(captured.output, "`norm(state)` must be 1")
 
     struct InvalidState2 end
+    QuantumPropagators.Interfaces.supports_inplace(::InvalidState2) = true
     state = InvalidState2()
     Base.similar(::InvalidState2) = InvalidState2()
-    test_logger = QuantumTestLogger()
-    with_logger(test_logger) do
-        @test check_state(state; normalized=true) ≡ false
+    captured = IOCapture.capture() do
+        check_state(state; normalized=true)
     end
-    @test "`copyto!(other, state)` must be defined" ∈ test_logger
+    @test captured.value ≡ false
+    @test contains(captured.output, "`copyto!(other, state)` must be defined")
 
     struct InvalidState3 end
+    QuantumPropagators.Interfaces.supports_inplace(::InvalidState3) = true
     state = InvalidState3()
     Base.similar(::InvalidState3) = InvalidState3()
     Base.copyto!(a::InvalidState3, b::InvalidState3) = a
-    test_logger = QuantumTestLogger()
-    with_logger(test_logger) do
-        @test check_state(state; normalized=true) ≡ false
+    captured = IOCapture.capture() do
+        check_state(state; normalized=true)
     end
-    @test "`similar(state)` must return a valid state" ∈ test_logger
-    @test "On `similar(state)`: " ∈ test_logger
-
+    @test captured.value ≡ false
+    @test contains(captured.output, "`similar(state)` must return a valid state")
+    @test contains(captured.output, "On `similar(state)`: ")
 
     struct InvalidState4
         Ψ
     end
+    QuantumPropagators.Interfaces.supports_inplace(::InvalidState4) = true
     Base.similar(state::InvalidState4) = InvalidState4(similar(state.Ψ))
     Base.copy(state::InvalidState4) = InvalidState4(copy(state.Ψ))
     Base.copyto!(a::InvalidState4, b::InvalidState4) = copyto!(a.Ψ, b.Ψ)
@@ -157,20 +195,20 @@ end
     Base.:-(a::InvalidState4, b::InvalidState4) = InvalidState4(a.Ψ - b.Ψ)
     Base.:*(α::Number, state::InvalidState4) = InvalidState4(α * state.Ψ)
     state = InvalidState4([1im, 0])
-    test_logger = QuantumTestLogger()
-    with_logger(test_logger) do
-        @test check_state(state; normalized=true) ≡ false
+    captured = IOCapture.capture() do
+        check_state(state; normalized=true)
     end
-    @test "`lmul!(c, state)` for a scalar `c` must be defined" ∈ test_logger
-    @test "`lmul!(0.0, state)` must produce a state with norm 0" ∈ test_logger
-    @test "`axpy!(c, state, other)` must be defined" ∈ test_logger
+    @test captured.value ≡ false
+    @test contains(captured.output, "`lmul!(c, state)` for a scalar `c` must be defined")
+    @test contains(captured.output, "`lmul!(0.0, state)` must produce a state with norm 0")
+    @test contains(captured.output, "`axpy!(c, state, other)` must be defined")
 
     state = [1, 0, 0, 0]
-    test_logger = QuantumTestLogger()
-    with_logger(test_logger) do
-        @test check_state(state; normalized=true) ≡ false
+    captured = IOCapture.capture() do
+        check_state(state; normalized=true)
     end
-    @test "`state ⋅ state` must return a Complex number type" ∈ test_logger
+    @test captured.value ≡ false
+    @test contains(captured.output, "`state ⋅ state` must return a Complex number type")
 
 end
 
@@ -183,12 +221,12 @@ end
 
     propagator = InvalidPropagatorEmpty()
 
-    test_logger = QuantumTestLogger()
-    with_logger(test_logger) do
-        @test check_propagator(propagator) ≡ false
+    captured = IOCapture.capture() do
+        check_propagator(propagator)
     end
+    @test captured.value ≡ false
 
-    @test "does not have the required properties" ∈ test_logger
+    @test contains(captured.output, "does not have the required properties")
 
     N = 10
     tlist = collect(range(0, 100, length=1001))
@@ -198,15 +236,13 @@ end
 
     propagator = init_prop(Ψ, Ĥ, tlist; method=:invalid_propagator_no_methods)
 
-    test_logger = QuantumTestLogger()
-    with_logger(test_logger) do
-        @test check_propagator(propagator) ≡ false
+    captured = IOCapture.capture() do
+        check_propagator(propagator)
     end
 
-    @test "`prop_step!(propagator)` must be defined" ∈ test_logger
-    @test "Failed to run `prop_step!(propagator)`" ∈ test_logger
-    @test "`reinit_prop!` must be defined" ∈ test_logger
-
+    @test contains(captured.output, "`prop_step!(propagator)` must be defined")
+    @test contains(captured.output, "Failed to run `prop_step!(propagator)`")
+    @test contains(captured.output, "`reinit_prop!` must be defined")
 
     propagator = init_prop(
         Ψ,
@@ -216,15 +252,21 @@ end
         inplace=true,
         backward=false
     )
-    test_logger = QuantumTestLogger()
-    with_logger(test_logger) do
-        @test check_propagator(propagator) ≡ false
+    captured = IOCapture.capture() do
+        check_propagator(propagator)
     end
-    @test "propagator.t ≠ propagator.tlist[begin]" ∈ test_logger
-    @test "`set_t!(propagator, t)` must set propagator.t" ∈ test_logger
-    @test "`prop_step!(propagator)` at final t=0.1 must return `nothing`" ∈ test_logger
-    @test "`propagator.parameters` must be a dict" ∈ test_logger
-    @test "`reinit_prop!(propagator, state)` must reset `propagator.t`" ∈ test_logger
+    @test captured.value ≡ false
+    @test contains(captured.output, "propagator.t ≠ propagator.tlist[begin]")
+    @test contains(captured.output, "`set_t!(propagator, t)` must set propagator.t")
+    @test contains(
+        captured.output,
+        "`prop_step!(propagator)` at final t=0.1 must return `nothing`"
+    )
+    @test contains(captured.output, "`propagator.parameters` must be a dict")
+    @test contains(
+        captured.output,
+        "`reinit_prop!(propagator, state)` must reset `propagator.t`"
+    )
 
     propagator = init_prop(
         Ψ,
@@ -234,15 +276,19 @@ end
         inplace=false,
         backward=true
     )
-    test_logger = QuantumTestLogger()
-    with_logger(test_logger) do
-        @test check_propagator(propagator) ≡ false
+    captured = IOCapture.capture() do
+        check_propagator(propagator)
     end
-    @test "propagator.t ≠ propagator.tlist[end]" ∈ test_logger
-    @test "For a not-in-place propagator, the state returned by `prop_step!` must be a new object" ∈
-          test_logger
-    @test "`prop_step!` must advance `propagator.t` forward or backward one step on the time grid" ∈
-          test_logger
+    @test captured.value ≡ false
+    @test contains(captured.output, "propagator.t ≠ propagator.tlist[end]")
+    @test contains(
+        captured.output,
+        "For a not-in-place propagator, the state returned by `prop_step!` must be a new object"
+    )
+    @test contains(
+        captured.output,
+        "`prop_step!` must advance `propagator.t` forward or backward one step on the time grid"
+    )
 
     propagator = init_prop(
         Ψ,
@@ -252,15 +298,19 @@ end
         inplace=true,
         backward=false
     )
-    test_logger = QuantumTestLogger()
-    with_logger(test_logger) do
-        @test check_propagator(propagator) ≡ false
+    captured = IOCapture.capture() do
+        check_propagator(propagator)
     end
-    @test "For an in-place propagator, the state returned by `prop_step!` must be the `propagator.state` object" ∈
-          test_logger
-    @test "`set_state!(propagator, state)` for an in-place propagator must overwrite `propagator.state` in-place." ∈
-          test_logger
-    @test "`reinit_prop!(propagator, state)` must be idempotent" ∈ test_logger
+    @test captured.value ≡ false
+    @test contains(
+        captured.output,
+        "For an in-place propagator, the state returned by `prop_step!` must be the `propagator.state` object"
+    )
+    @test contains(
+        captured.output,
+        "`set_state!(propagator, state)` for an in-place propagator must overwrite `propagator.state` in-place."
+    )
+    @test contains(captured.output, "`reinit_prop!(propagator, state)` must be idempotent")
 
     propagator = init_prop(
         Ψ,
@@ -270,13 +320,18 @@ end
         inplace=false,
         backward=true
     )
-    test_logger = QuantumTestLogger()
-    with_logger(test_logger) do
-        @test check_propagator(propagator) ≡ false
+    captured = IOCapture.capture() do
+        check_propagator(propagator)
     end
-    @test "For a not-in-place propagator, the state returned by `prop_step!` must be a new object" ∈
-          test_logger
-    @test "`reinit_prop!` must be defined and re-initialize the propagator" ∈ test_logger
+    @test captured.value ≡ false
+    @test contains(
+        captured.output,
+        "For a not-in-place propagator, the state returned by `prop_step!` must be a new object"
+    )
+    @test contains(
+        captured.output,
+        "`reinit_prop!` must be defined and re-initialize the propagator"
+    )
 
     propagator = init_prop(
         Ψ,
@@ -286,11 +341,13 @@ end
         inplace=true,
         backward=false
     )
-    test_logger = QuantumTestLogger()
-    with_logger(test_logger) do
-        @test check_propagator(propagator) ≡ false
+    captured = IOCapture.capture() do
+        check_propagator(propagator)
     end
-    @test "prop_step! must return a valid state until time grid is exhausted" ∈ test_logger
-
+    @test captured.value ≡ false
+    @test contains(
+        captured.output,
+        "prop_step! must return a valid state until time grid is exhausted"
+    )
 
 end


### PR DESCRIPTION
We support both mutating and non-mutating propagators. Mutation is better for large Hilbert spaces. Non-mutation is better for small Hilbert spaces (`StaticArrays`!) or when trying to use automatic differentiation.

There are some subtleties in finding the correct abstraction. It is not as simple as using the built-in `ismutable` for states or operators and making decisions based on that: Anytime we use custom structs, unless that struct is explicitly defined as `mutable`, it is considered immutable. However, we can still use in-place propagation, mutating the mutable *components* of that struct.

Instead of overloading `ismutable`, we define the in-place or not-in-place interface explicitly via the required behavior guaranteed by the `check_state`, `check_generator`, and `check_operator` functions.

A new `QuantumPropagators.Interfaces.supports_inplace` function is available to check whether a given `state` or `operator` type is suitable for in-place operations.