### PR TITLE
Make the storage own its data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Also see the [GitHub Releases](https://github.com/JuliaQuantumControl/QuantumPro
 
 ## [Unreleased]
 
+* Added: `QuantumPropagators.Interfaces.check_storage`, which verifies that a storage implementation fulfills the storage contract [[#119], [#120]]
+* Fixed: `write_to_storage!` now stores a copy of any mutable data, so that the storage owns its data. Previously, storing the state of an in-place propagation at every time step could leave all slots aliasing a single buffer [[#119], [#120]]
+
 ## [v0.9.0] — 2026-06-15
 
 * Added: `ExponentialUtilitiesPropagator`, a propagator based on `expv` from [ExponentialUtilities.jl](https://github.com/SciML/ExponentialUtilities.jl), with Krylov-subspace caching for in-place propagation [[#97]]
@@ -233,3 +236,5 @@ Initial public release
 [#108]: https://github.com/JuliaQuantumControl/QuantumPropagators.jl/pull/108
 [#110]: https://github.com/JuliaQuantumControl/QuantumPropagators.jl/pull/110
 [#111]: https://github.com/JuliaQuantumControl/QuantumPropagators.jl/pull/111
+[#119]: https://github.com/JuliaQuantumControl/QuantumPropagators.jl/issues/119
+[#120]: https://github.com/JuliaQuantumControl/QuantumPropagators.jl/pull/120

--- a/docs/src/storage.md
+++ b/docs/src/storage.md
@@ -22,12 +22,12 @@ After each propagation step, with a propagated state at time slot `i`,
 1. [`data = QuantumPropagators.Storage.map_observables(observables, tlist, i, state)`](@ref QuantumPropagators.Storage.map_observables) generates `data` from the propagated state
 2. [`QuantumPropagators.Storage.write_to_storage!(storage, i, data)`](@ref QuantumPropagators.Storage.write_to_storage!) places that `data` into `storage` for time slot `i`
 
-After [`propagate`](@ref) returns, the [`QuantumPropagators.Storage.get_from_storage!`](@ref) routine can be used to extract data from any time slot. This interface hides the internal memory organization of `storage`, which is set up by [`init_storage`](@ref QuantumPropagators.Storage.init_storage) based on the type of `state` and the given `observables`. This system can be extended with multiple dispatch, allowing to optimize the `storage` for custom data types. Obviously, [`init_storage`](@ref QuantumPropagators.Storage.init_storage), [`map_observables`](@ref QuantumPropagators.Storage.map_observables), [`write_to_storage!`](@ref QuantumPropagators.Storage.write_to_storage!), and [`get_from_storage!`](@ref QuantumPropagators.Storage.get_from_storage!) must all be consistent.
+After [`propagate`](@ref) returns, the [`QuantumPropagators.Storage.get_from_storage!`](@ref) routine can be used to extract data from any time slot. This interface hides the internal memory organization of `storage`, which is set up by [`init_storage`](@ref QuantumPropagators.Storage.init_storage) based on the type of `state` and the given `observables`. This system can be extended with multiple dispatch, allowing to optimize the `storage` for custom data types. Obviously, [`init_storage`](@ref QuantumPropagators.Storage.init_storage), [`map_observables`](@ref QuantumPropagators.Storage.map_observables), [`write_to_storage!`](@ref QuantumPropagators.Storage.write_to_storage!), and [`get_from_storage!`](@ref QuantumPropagators.Storage.get_from_storage!) must all be consistent, see [the storage contract](@ref storage-contract).
 
 The default implementation of these routine uses either a standard Vector or a Matrix as `storage`.
 
-Roughly speaking, when storing states, if the state of some arbitrary type,
-the storage will be a Vector where the i'th entry points to a copy of the propagated state at the i'th time slot. If the state is a Vector, the storage will be a Matrix containing the state for the i'th time slot in the i'th column.
+Roughly speaking, when storing states, if the state is of some arbitrary type,
+the storage will be a Vector where the i'th entry holds a copy of the propagated state at the i'th time slot. If the state is a Vector, the storage will be a Matrix containing the state for the i'th time slot in the i'th column.
 
 When a tuple of `observables` is passed to [`propagate`](@ref), if [`map_observables`](@ref QuantumPropagators.Storage.map_observables) returns data of the same type for each observable, `storage` will be a Matrix containing the values from the different observables for the i'th time slot in the i'th column. This would be typical for the storage of expectation values, e.g. with
 
@@ -62,8 +62,21 @@ observables=(state->dot(state, Ô₁, state), state->count_poplevels(state))
 where `count_poplevels` is a function that counts the number of levels with
 non-zero population, the resulting `storage` would be a `Vector{Tuple{Float64, Int64}}`.
 
-If there is a single observable that yields a vector, that vector is stored in the i'th column of a `storage` matrix. This is in fact what happens when storing the propagated states (`observables=(Ψ->copy(Ψ), )`) if `Ψ` is a Vector, but there are other use cases, such as calculating the population in all levels in one go, with
+If there is a single observable that yields a vector, that vector is stored in the i'th column of a `storage` matrix. This is in fact what happens when storing the propagated states (`observables=(Ψ->Ψ, )`) if `Ψ` is a Vector, but there are other use cases, such as calculating the population in all levels in one go, with
 `observables=(Ψ -> abs.(Ψ).^2, )`.
 
-If there is a single variable that yields a non-vector object, `storage` will be a Vector where the i'th entry points to the object. This is in fact what happens by default when storing states  that are e.g. instances of
+If there is a single observable that yields a non-vector object, `storage` will be a Vector where the i'th entry holds a copy of the object. This is in fact what happens by default when storing states  that are e.g. instances of
 `QuantumOptics.Ket`. In such a case, it might be advisable to add new methods for [`QuantumPropagators.Storage.init_storage`](@ref) and [`QuantumPropagators.Storage.write_to_storage!`](@ref) that implement a more efficient in-place storage.
+
+
+## [The storage contract](@id storage-contract)
+
+A `storage` object is created by [`init_storage`](@ref QuantumPropagators.Storage.init_storage), written to by [`write_to_storage!`](@ref QuantumPropagators.Storage.write_to_storage!), and read back by [`get_from_storage`](@ref QuantumPropagators.Storage.get_from_storage) or [`get_from_storage!`](@ref QuantumPropagators.Storage.get_from_storage!). Together, these four functions guarantee the following, for any `storage = init_storage(data, nt)` and any slot `i` in `1:nt`:
+
+1. What you put in is what you get out. After `write_to_storage!(storage, i, data)`, both `get_from_storage(storage, i)` and `get_from_storage!(buffer, storage, i)` reproduce the value that `data` had at the time of the write.
+
+2. The storage owns its data. Modifying `data` after the write does not change what is stored, and writing to one slot does not change any other slot. This holds even when the caller passes the same object on every write, which is the normal situation when storing the states of an in-place propagation: [`prop_step!`](@ref) returns the same buffer at every time step.
+
+3. The result of [`get_from_storage`](@ref QuantumPropagators.Storage.get_from_storage) is read-only. It may alias the internals of `storage`, so mutating it may corrupt the storage. Use [`get_from_storage!`](@ref QuantumPropagators.Storage.get_from_storage!) to obtain data the caller may modify.
+
+Custom [`init_storage`](@ref QuantumPropagators.Storage.init_storage), [`write_to_storage!`](@ref QuantumPropagators.Storage.write_to_storage!), and [`get_from_storage!`](@ref QuantumPropagators.Storage.get_from_storage!) methods must be mutually consistent, and must uphold the guarantees above. Use [`check_storage`](@ref QuantumPropagators.Interfaces.check_storage) to verify them.

--- a/docs/src/storage.md
+++ b/docs/src/storage.md
@@ -73,7 +73,7 @@ If there is a single observable that yields a non-vector object, `storage` will 
 
 A `storage` object is created by [`init_storage`](@ref QuantumPropagators.Storage.init_storage), written to by [`write_to_storage!`](@ref QuantumPropagators.Storage.write_to_storage!), and read back by [`get_from_storage`](@ref QuantumPropagators.Storage.get_from_storage) or [`get_from_storage!`](@ref QuantumPropagators.Storage.get_from_storage!). Together, these four functions guarantee the following, for any `storage = init_storage(data, nt)` and any slot `i` in `1:nt`:
 
-1. What you put in is what you get out. After `write_to_storage!(storage, i, data)`, both `get_from_storage(storage, i)` and `get_from_storage!(buffer, storage, i)` reproduce the value that `data` had at the time of the write.
+1. What you put in is what you get out. After `write_to_storage!(storage, i, data)`, `get_from_storage(storage, i)` reproduces the value that `data` had at the time of the write, and so does `get_from_storage!(buffer, storage, i)` for data that supports in-place extraction.
 
 2. The storage owns its data. Modifying `data` after the write does not change what is stored, and writing to one slot does not change any other slot. This holds even when the caller passes the same object on every write, which is the normal situation when storing the states of an in-place propagation: [`prop_step!`](@ref) returns the same buffer at every time step.
 

--- a/src/QuantumPropagators.jl
+++ b/src/QuantumPropagators.jl
@@ -44,6 +44,7 @@ export init_prop, reinit_prop!, prop_step!
 module Interfaces
     export supports_inplace, supports_vector_interface, supports_matrix_interface
     export check_operator, check_state, check_tlist, check_amplitude
+    export check_storage
     export check_control, check_generator, check_propagator
     export check_parameterized_function, check_parameterized
     include("interfaces/supports_inplace.jl")
@@ -51,6 +52,7 @@ module Interfaces
     include("interfaces/supports_matrix_interface.jl")
     include("interfaces/utils.jl")
     include("interfaces/state.jl")
+    include("interfaces/storage.jl")
     include("interfaces/tlist.jl")
     include("interfaces/operator.jl")
     include("interfaces/amplitude.jl")

--- a/src/interfaces/state.jl
+++ b/src/interfaces/state.jl
@@ -22,7 +22,7 @@ verifies the following requirements:
   This is the *definition* of a Hilbert space, a.k.a a "complete inner product
   space" or more precisely a "Banach space (normed vector space) where the
   norm is induced by an inner product".
-* The [`QuantumPropagators.Interfaces.supports_inplace](@ref) method must be
+* The [`QuantumPropagators.Interfaces.supports_inplace`](@ref) method must be
   defined for `state`
 
 Any `state` must support the following not-in-place operations:

--- a/src/interfaces/storage.jl
+++ b/src/interfaces/storage.jl
@@ -1,0 +1,331 @@
+# SPDX-FileCopyrightText: © 2021 Michael Goerz <mail@michaelgoerz.net>
+#
+# SPDX-License-Identifier: MIT
+
+using LinearAlgebra: norm
+using Random: AbstractRNG, default_rng
+
+using ..Storage:
+    init_storage, write_to_storage!, get_from_storage, get_from_storage!, map_observables
+
+
+# Deviation between the stored and the expected data. Falls back to an exact
+# comparison for data that does not support `norm` and `-` (e.g., tuples of
+# mixed observable values).
+function _storage_mismatch(a, b)
+    try
+        return norm(a - b)
+    catch
+        return isequal(a, b) ? 0.0 : Inf
+    end
+end
+
+
+# Read back every slot of `storage` and compare it to `expected`. Returns
+# `true` if all slots match within `atol`.
+function _check_storage_roundtrip(storage, expected, atol, quiet, msg)
+    for n in eachindex(expected)
+        local delta
+        try
+            delta = _storage_mismatch(get_from_storage(storage, n), expected[n])
+        catch exc
+            quiet || @error(
+                "$msg: `get_from_storage(storage, $n)` must return the data written to slot $n.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
+            return false
+        end
+        if !(delta <= atol)
+            quiet || @error "$msg: slot $n does not match the written data" delta atol
+            return false
+        end
+    end
+    return true
+end
+
+
+"""Check the storage implementation for a `state` or for arbitrary `data`.
+
+```julia
+@test check_storage(state, tlist; rng=Random.default_rng(), atol=1e-14, quiet=false)
+```
+
+verifies that storing `state` objects in a `storage` object created by 
+[`init_storage`](@ref QuantumPropagators.Storage.init_storage)
+fulfills [the storage contract](@ref storage-contract) for every point
+of `tlist`.
+
+```julia
+@test check_storage(state, tlist, observables; rng=Random.default_rng(), atol=1e-14, quiet=false)
+```
+
+verifies the same for the data produced by applying `observables` to `state`,
+i.e., the full
+[`map_observables`](@ref QuantumPropagators.Storage.map_observables) →
+[`write_to_storage!`](@ref QuantumPropagators.Storage.write_to_storage!) →
+[`get_from_storage`](@ref QuantumPropagators.Storage.get_from_storage) pipeline
+that [`propagate`](@ref QuantumPropagators.propagate) relies on.
+
+```julia
+@test check_storage(data, nt; transform=(data -> data), atol=1e-14, quiet=false)
+```
+
+verifies the write/read round trip for `nt` slots of arbitrary `data`, where
+successive values are obtained as `data = transform(data)`. This form checks
+ownership only if `transform` mutates its argument in place and returns it;
+with the default `transform`, the same object is written to every slot.
+
+The different methods of the check mirror the methods of
+[`init_storage`](@ref QuantumPropagators.Storage.init_storage).
+The two state-based forms assume that `state` is a valid state (it passes
+[`check_state`](@ref QuantumPropagators.Interfaces.check_state)) and that
+`tlist` is a valid time grid (it passes
+[`check_tlist`](@ref QuantumPropagators.Interfaces.check_tlist)).
+They verify the following:
+
+1. Round trip: Each slot is filled with a *fresh* state object of known
+   value, and every slot read back with
+   [`get_from_storage`](@ref QuantumPropagators.Storage.get_from_storage) must
+   reproduce the value written to it.
+2. Ownership (only if [`supports_inplace(state)`](@ref QuantumPropagators.Interfaces.supports_inplace)):
+   Each slot is filled from a *single* state object that is mutated in place
+   between the writes. Reading the slots back, via both
+   [`get_from_storage`](@ref QuantumPropagators.Storage.get_from_storage) and
+   [`get_from_storage!`](@ref QuantumPropagators.Storage.get_from_storage!),
+   must reproduce the values as of the time of each write. This is the part
+   that detects a storage that keeps a reference to mutable data: under
+   aliasing, every slot reads back as the final value.
+
+The function returns `true` for a valid storage implementation and `false`
+otherwise. Unless `quiet=true`, it will log an error to indicate which of the
+conditions failed.
+"""
+function check_storage(
+    state,
+    tlist;
+    rng::AbstractRNG = default_rng(),
+    atol = 1e-14,
+    quiet = false
+)
+
+    success = true
+    nt = length(tlist)
+    state₀ = state
+
+    inplace = false
+    try
+        inplace = supports_inplace(state₀)
+    catch exc
+        quiet || @error(
+            "check_storage: The `QuantumPropagators.Interfaces.supports_inplace` method must be defined for type `$(typeof(state₀))`.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
+        return false
+    end
+
+    # 1. Round trip: a fresh state object for every slot.
+    #
+    # Every value is derived from the original state with a factor in
+    # [0.5, 1.5) so that all slots stay at order-1 values for any `nt`.
+    # Cumulative rescaling would make the norm drift below `atol` after a few
+    # dozen slots, leaving late slots effectively unchecked.
+    try
+        storage = init_storage(state₀, tlist)
+        expected = Any[state₀]
+        write_to_storage!(storage, 1, state₀)
+        for n = 2:nt
+            Ψ = (0.5 + rand(rng)) * state₀  # fresh object; `c * state`
+            write_to_storage!(storage, n, Ψ)
+            push!(expected, Ψ)
+        end
+        success &= _check_storage_roundtrip(
+            storage,
+            expected,
+            atol,
+            quiet,
+            "check_storage (round trip)"
+        )
+    catch exc
+        quiet || @error(
+            "check_storage: `init_storage(state, tlist)` and `write_to_storage!` must be defined and compatible.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
+        return false
+    end
+
+    # 2. Ownership: a single state object, mutated in place after each write.
+    #    The storage must retain the value as of the time of the write.
+    if inplace
+        ok = false
+        expected = Any[]
+        storage = nothing
+        try
+            storage = init_storage(state₀, tlist)
+            Ψ = copy(state₀)
+            expected = Any[copy(Ψ)]  # the records must be copies!
+            write_to_storage!(storage, 1, Ψ)
+            for n = 2:nt
+                copyto!(Ψ, (0.5 + rand(rng)) * state₀)  # in-place mutation
+                write_to_storage!(storage, n, Ψ)
+                push!(expected, copy(Ψ))
+            end
+            ok = _check_storage_roundtrip(
+                storage,
+                expected,
+                atol,
+                quiet,
+                "check_storage (ownership): the storage must own its data, not keep a reference to it"
+            )
+            success &= ok
+        catch exc
+            quiet || @error(
+                "check_storage: `write_to_storage!` must be defined for a mutable state.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
+            return false
+        end
+        if ok  # also check in-place extraction
+            try
+                Ψ = similar(state₀)
+                for n = 1:nt
+                    get_from_storage!(Ψ, storage, n)
+                    delta = _storage_mismatch(Ψ, expected[n])
+                    if !(delta <= atol)
+                        quiet ||
+                            @error "check_storage: `get_from_storage!` at slot $n does not match the written data" delta atol
+                        success = false
+                        break
+                    end
+                end
+            catch exc
+                quiet || @error(
+                    "check_storage: `get_from_storage!(state, storage, i)` must be defined for a mutable state.",
+                    exception = (exc, catch_abbreviated_backtrace())
+                )
+                success = false
+            end
+        end
+    end
+
+    return success
+
+end
+
+
+function check_storage(
+    state,
+    tlist,
+    observables;
+    rng::AbstractRNG = default_rng(),
+    atol = 1e-14,
+    quiet = false
+)
+
+    success = true
+    nt = length(tlist)
+    state₀ = state
+
+    inplace = false
+    try
+        inplace = supports_inplace(state₀)
+    catch exc
+        quiet || @error(
+            "check_storage: The `QuantumPropagators.Interfaces.supports_inplace` method must be defined for type `$(typeof(state₀))`.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
+        return false
+    end
+
+    try
+        storage = init_storage(state₀, tlist, observables)
+        data = map_observables(observables, tlist, 1, state₀)
+        expected = Any[deepcopy(data)]
+        write_to_storage!(storage, 1, data)
+        for n = 2:nt
+            Ψ = (0.5 + rand(rng)) * state₀
+            data = map_observables(observables, tlist, n, Ψ)
+            write_to_storage!(storage, n, data)
+            push!(expected, deepcopy(data))
+        end
+        success &= _check_storage_roundtrip(
+            storage,
+            expected,
+            atol,
+            quiet,
+            "check_storage (observables, round trip)"
+        )
+    catch exc
+        quiet || @error(
+            "check_storage: `init_storage(state, tlist, observables)`, `map_observables`, and `write_to_storage!` must be defined and compatible.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
+        return false
+    end
+
+    if inplace
+        try
+            storage = init_storage(state₀, tlist, observables)
+            Ψ = copy(state₀)
+            data = map_observables(observables, tlist, 1, Ψ)
+            expected = Any[deepcopy(data)]
+            write_to_storage!(storage, 1, data)
+            for n = 2:nt
+                copyto!(Ψ, (0.5 + rand(rng)) * state₀)
+                data = map_observables(observables, tlist, n, Ψ)
+                write_to_storage!(storage, n, data)
+                push!(expected, deepcopy(data))
+            end
+            success &= _check_storage_roundtrip(
+                storage,
+                expected,
+                atol,
+                quiet,
+                "check_storage (observables, ownership): the storage must own its data, not keep a reference to it"
+            )
+        catch exc
+            quiet || @error(
+                "check_storage: `map_observables` and `write_to_storage!` must be defined for a mutable state.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
+            return false
+        end
+    end
+
+    return success
+
+end
+
+
+function check_storage(
+    data,
+    nt::Integer;
+    transform = (data -> data),
+    atol = 1e-14,
+    quiet = false
+)
+
+    try
+        storage = init_storage(data, nt)
+        expected = Any[deepcopy(data)]
+        write_to_storage!(storage, 1, data)
+        for n = 2:nt
+            data = transform(data)
+            write_to_storage!(storage, n, data)
+            push!(expected, deepcopy(data))
+        end
+        return _check_storage_roundtrip(
+            storage,
+            expected,
+            atol,
+            quiet,
+            "check_storage (data)"
+        )
+    catch exc
+        quiet || @error(
+            "check_storage: `init_storage(data, nt)` and `write_to_storage!` must be defined and compatible.",
+            exception = (exc, catch_abbreviated_backtrace())
+        )
+        return false
+    end
+
+end

--- a/src/interfaces/storage.jl
+++ b/src/interfaces/storage.jl
@@ -110,14 +110,14 @@ function check_storage(
 
     success = true
     nt = length(tlist)
-    state₀ = state
+    state_initial = state
 
     inplace = false
     try
-        inplace = supports_inplace(state₀)
+        inplace = supports_inplace(state_initial)
     catch exc
         quiet || @error(
-            "check_storage: The `QuantumPropagators.Interfaces.supports_inplace` method must be defined for type `$(typeof(state₀))`.",
+            "check_storage: The `QuantumPropagators.Interfaces.supports_inplace` method must be defined for type `$(typeof(state_initial))`.",
             exception = (exc, catch_abbreviated_backtrace())
         )
         return false
@@ -130,13 +130,13 @@ function check_storage(
     # Cumulative rescaling would make the norm drift below `atol` after a few
     # dozen slots, leaving late slots effectively unchecked.
     try
-        storage = init_storage(state₀, tlist)
-        expected = Any[state₀]
-        write_to_storage!(storage, 1, state₀)
+        storage = init_storage(state_initial, tlist)
+        expected = Any[state_initial]
+        write_to_storage!(storage, 1, state_initial)
         for n = 2:nt
-            Ψ = (0.5 + rand(rng)) * state₀  # fresh object; `c * state`
-            write_to_storage!(storage, n, Ψ)
-            push!(expected, Ψ)
+            state = (0.5 + rand(rng)) * state_initial  # fresh object; `c * state`
+            write_to_storage!(storage, n, state)
+            push!(expected, state)
         end
         success &= _check_storage_roundtrip(
             storage,
@@ -160,15 +160,19 @@ function check_storage(
         expected = Any[]
         storage = nothing
         try
-            storage = init_storage(state₀, tlist)
-            Ψ = copy(state₀)
-            expected = Any[copy(Ψ)]  # the records must be copies!
-            write_to_storage!(storage, 1, Ψ)
+            storage = init_storage(state_initial, tlist)
+            state = copy(state_initial)
+            expected = Any[copy(state)]  # the records must be copies!
+            write_to_storage!(storage, 1, state)
             for n = 2:nt
-                copyto!(Ψ, (0.5 + rand(rng)) * state₀)  # in-place mutation
-                write_to_storage!(storage, n, Ψ)
-                push!(expected, copy(Ψ))
+                copyto!(state, (0.5 + rand(rng)) * state_initial)  # in-place mutation
+                write_to_storage!(storage, n, state)
+                push!(expected, copy(state))
             end
+            # One more mutation, with no write following it: without this,
+            # the final slot still agrees with `state`, and a storage that
+            # aliases only that slot would pass.
+            copyto!(state, (0.5 + rand(rng)) * state_initial)
             ok = _check_storage_roundtrip(
                 storage,
                 expected,
@@ -186,10 +190,10 @@ function check_storage(
         end
         if ok  # also check in-place extraction
             try
-                Ψ = similar(state₀)
+                state = similar(state_initial)
                 for n = 1:nt
-                    get_from_storage!(Ψ, storage, n)
-                    delta = _storage_mismatch(Ψ, expected[n])
+                    get_from_storage!(state, storage, n)
+                    delta = _storage_mismatch(state, expected[n])
                     if !(delta <= atol)
                         quiet ||
                             @error "check_storage: `get_from_storage!` at slot $n does not match the written data" delta atol
@@ -223,27 +227,27 @@ function check_storage(
 
     success = true
     nt = length(tlist)
-    state₀ = state
+    state_initial = state
 
     inplace = false
     try
-        inplace = supports_inplace(state₀)
+        inplace = supports_inplace(state_initial)
     catch exc
         quiet || @error(
-            "check_storage: The `QuantumPropagators.Interfaces.supports_inplace` method must be defined for type `$(typeof(state₀))`.",
+            "check_storage: The `QuantumPropagators.Interfaces.supports_inplace` method must be defined for type `$(typeof(state_initial))`.",
             exception = (exc, catch_abbreviated_backtrace())
         )
         return false
     end
 
     try
-        storage = init_storage(state₀, tlist, observables)
-        data = map_observables(observables, tlist, 1, state₀)
+        storage = init_storage(state_initial, tlist, observables)
+        data = map_observables(observables, tlist, 1, state_initial)
         expected = Any[deepcopy(data)]
         write_to_storage!(storage, 1, data)
         for n = 2:nt
-            Ψ = (0.5 + rand(rng)) * state₀
-            data = map_observables(observables, tlist, n, Ψ)
+            state = (0.5 + rand(rng)) * state_initial
+            data = map_observables(observables, tlist, n, state)
             write_to_storage!(storage, n, data)
             push!(expected, deepcopy(data))
         end
@@ -264,17 +268,22 @@ function check_storage(
 
     if inplace
         try
-            storage = init_storage(state₀, tlist, observables)
-            Ψ = copy(state₀)
-            data = map_observables(observables, tlist, 1, Ψ)
+            storage = init_storage(state_initial, tlist, observables)
+            state = copy(state_initial)
+            data = map_observables(observables, tlist, 1, state)
             expected = Any[deepcopy(data)]
             write_to_storage!(storage, 1, data)
             for n = 2:nt
-                copyto!(Ψ, (0.5 + rand(rng)) * state₀)
-                data = map_observables(observables, tlist, n, Ψ)
+                copyto!(state, (0.5 + rand(rng)) * state_initial)
+                data = map_observables(observables, tlist, n, state)
                 write_to_storage!(storage, n, data)
                 push!(expected, deepcopy(data))
             end
+            # Mutate once more without writing, so that observables holding
+            # on to `state` or to a reused buffer expose an alias in the final
+            # slot as well.
+            copyto!(state, (0.5 + rand(rng)) * state_initial)
+            map_observables(observables, tlist, nt, state)
             success &= _check_storage_roundtrip(
                 storage,
                 expected,
@@ -313,6 +322,9 @@ function check_storage(
             write_to_storage!(storage, n, data)
             push!(expected, deepcopy(data))
         end
+        # One more transform, with no write following it: for an in-place
+        # `transform`, this exposes a storage that aliases only the final slot.
+        transform(data)
         return _check_storage_roundtrip(
             storage,
             expected,

--- a/src/propagate.jl
+++ b/src/propagate.jl
@@ -15,8 +15,9 @@ using .Interfaces: check_state, check_generator, check_tlist, supports_inplace
 # this private: It doesn't combine with other observables and depends on
 # internals of the default init_storage.
 struct _StoreState end
-map_observables(::_StoreState, tlist, i, state) = copy(state)
-map_observables(::_StoreState, tlist, i, state::Vector) = state
+# No copy here: `write_to_storage!` takes ownership of the data it is given,
+# see the storage contract in the `QuantumPropagators.Storage` documentation.
+map_observables(::_StoreState, tlist, i, state) = state
 
 
 # Work around https://github.com/timholy/ProgressMeter.jl/issues/214

--- a/src/storage.jl
+++ b/src/storage.jl
@@ -139,6 +139,14 @@ end
 # Note that `ismutable` would be the *wrong* criterion here: an immutable
 # wrapper around a mutable array is not `isbits`, and storing it by reference
 # would expose the caller's buffer.
+#
+# This copies one level deep, via the type's own `copy`, and deliberately not
+# via `deepcopy`. A `copy` that leaves its result aliased to the original is a
+# broken `copy`, and `deepcopy` would be the wrong remedy: it also duplicates
+# whatever a state legitimately shares (a basis, a lookup table, a cached
+# operator), which is both wasteful at every time step and semantically wrong.
+# `copy` is also what `Interfaces.check_state` requires of a state, so relying
+# on anything stronger here would make types storable only by accident.
 _own(data) = isbits(data) ? data : copy(data)
 _own(data::Tuple) = map(_own, data)
 _own(data::NamedTuple) = map(_own, data)
@@ -179,7 +187,11 @@ function write_to_storage!(storage::AbstractVector, i::Integer, data)
 end
 
 function write_to_storage!(storage::Matrix{T}, i::Integer, data::Vector{T}) where {T}
-    storage[:, i] .= data  # copies, and thus takes ownership
+    # The column assignment copies the container, but for a mutable `T` it would
+    # store references to the elements, so those are owned individually. For a
+    # bits `T` (the common case), `_own` is the identity and this is a plain
+    # column assignment.
+    storage[:, i] .= _own.(data)
     return storage
 end
 

--- a/src/storage.jl
+++ b/src/storage.jl
@@ -9,6 +9,7 @@ using LinearAlgebra
 export init_storage, map_observables, map_observable, write_to_storage!
 export get_from_storage!, get_from_storage
 
+
 """Create a `storage` array for propagation.
 
 ```julia
@@ -33,6 +34,10 @@ creates a storage arrays suitable for storing `data` nt times, where
 `nt=length(tlist)`. By default, this will be a vector of `typeof(data)` and
 length `nt`, or a `n × nt` Matrix with the same `eltype` as `data` if `data` is
 a Vector of length `n`.
+
+Together with [`write_to_storage!`](@ref), [`get_from_storage`](@ref), and
+[`get_from_storage!`](@ref), the resulting `storage` fulfills the
+[storage contract](@ref storage-contract).
 """
 function init_storage(state, tlist::AbstractVector)
     nt = length(tlist)
@@ -127,30 +132,55 @@ function map_observable(observable::AbstractMatrix, tlist, i, state::AbstractVec
 end
 
 
+# Take ownership of `data` for storing it: return `data` itself if it is an
+# immutable value (`isbits`), which is provably safe to store by reference, and
+# an independent copy otherwise. The branch is resolved at compile time.
+#
+# Note that `ismutable` would be the *wrong* criterion here: an immutable
+# wrapper around a mutable array is not `isbits`, and storing it by reference
+# would expose the caller's buffer.
+_own(data) = isbits(data) ? data : copy(data)
+_own(data::Tuple) = map(_own, data)
+_own(data::NamedTuple) = map(_own, data)
+
+
 """Place data into `storage` for time slot `i`.
 
 ```julia
 write_to_storage!(storage, i, data)
 ```
 
-for a `storage` array created by [`init_storage`](@ref) stores the `data`
-obtained from [`map_observables`](@ref) at time slot `i`.
+stores the `data` obtained from [`map_observables`](@ref) in the `storage`
+array created by [`init_storage`](@ref), for the time slot `i`, and returns the
+modified `storage`.
 
 Conceptually, this corresponds roughly to `storage[i] = data`, but `storage`
 may have its own idea on how to store data for a specific time slot. For
-example, with the default [`init_storage`](@ref) Vector data will be stored in
+example, with the default [`init_storage`](@ref), Vector data will be stored in
 a matrix, and `write_to_storage!` will in this case write data to the i'th
 column of the matrix.
 
+The `storage` takes *ownership* of the written data: after the write, the
+`data` object belongs to the caller alone, and any subsequent modification of
+`data` must leave the stored value unchanged. The default implementation
+guarantees this by storing `copy(data)` for any `data` that is not an immutable
+value (`isbits`); a specialization may store `data` by reference only if its
+type proves that the caller cannot mutate it. See
+[the storage contract](@ref storage-contract).
+
 For a given type of `storage` and `data`, it is the developer's responsibility
-that [`init_storage`](@ref) and `write_to_storage!` are compatible.
+that [`init_storage`](@ref) and `write_to_storage!` are compatible. Use
+[`QuantumPropagators.Interfaces.check_storage`](@ref) to verify a custom
+implementation.
 """
 function write_to_storage!(storage::AbstractVector, i::Integer, data)
-    storage[i] = data
+    storage[i] = _own(data)
+    return storage
 end
 
 function write_to_storage!(storage::Matrix{T}, i::Integer, data::Vector{T}) where {T}
-    storage[:, i] .= data
+    storage[:, i] .= data  # copies, and thus takes ownership
+    return storage
 end
 
 
@@ -160,14 +190,18 @@ end
 get_from_storage!(data, storage, i)
 ```
 
-extracts data from the `storage` for the i'th time slot. Inverse of
-[`write_to_storage!`](@ref). This modifies `data` in-place. If
-`get_from_storage!` is implemented for arbitrary `observables`, it is the
-developer's responsibility
-that [`init_storage`](@ref),  [`write_to_storage!`](@ref), and
-`get_from_storage!` are compatible.
+extracts data from the `storage` for the i'th time slot and copies it into the
+pre-allocated `data`, which is returned. Inverse of
+[`write_to_storage!`](@ref). The resulting `data` is owned by the caller:
+modifying it must not affect the `storage`.
 
-To extract immutable `data`, the non-in-place version
+If `get_from_storage!` is implemented for arbitrary `observables`, it is the
+developer's responsibility that [`init_storage`](@ref),
+[`write_to_storage!`](@ref), and `get_from_storage!` are compatible. Use
+[`QuantumPropagators.Interfaces.check_storage`](@ref) to verify a custom
+implementation.
+
+To extract data for read-only use, the non-in-place version
 
 ```julia
 data = get_from_storage(storage, i)
@@ -179,13 +213,18 @@ get_from_storage!(data, storage::AbstractVector, i) = copyto!(data, storage[i])
 get_from_storage!(data, storage::Matrix, i) = copyto!(data, storage[:, i])
 
 
-"""Obtain immutable data from storage.
+"""Obtain read-only data from storage.
 
 ```julia
 data = get_from_storage(storage, i)
 ```
 
-See [`get_from_storage!`](@ref).
+extracts the data that was written to the i'th time slot with
+[`write_to_storage!`](@ref).
+
+The returned `data` may alias the internals of `storage` and must be treated as
+read-only: mutating it may corrupt the `storage`. Use
+[`get_from_storage!`](@ref) to obtain data that the caller may modify.
 """
 get_from_storage(storage::AbstractVector, i) = storage[i]
 get_from_storage(storage::Matrix, i) = storage[:, i]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,6 +92,11 @@ using SafeTestsets
         include("test_prop_interfaces.jl")
     end
 
+    println("\n* Storage (test_storage.jl):")
+    @time @safetestset "Storage" begin
+        include("test_storage.jl")
+    end
+
     println("\n* Propagate (test_propagate.jl):")
     @time @safetestset "Propagate" begin
         include("test_propagate.jl")

--- a/test/test_storage.jl
+++ b/test/test_storage.jl
@@ -18,19 +18,26 @@ import QuantumPropagators.Interfaces: supports_inplace
 import QuantumPropagators.Storage
 
 
-# A state that wraps a `Matrix`, to exercise the generic `Vector`-of-states
-# storage path with a type that is not an `AbstractArray`.
-struct GateState
+# States that wrap a `Matrix`, to exercise the generic `Vector`-of-states
+# storage path with a type that is not an `AbstractArray`. The two concrete
+# types select the two broken storages defined below.
+abstract type AbstractGateState end
+
+struct GateState <: AbstractGateState
     U::Matrix{ComplexF64}
 end
 
-supports_inplace(::Type{GateState}) = true
-Base.copy(Ψ::GateState) = GateState(copy(Ψ.U))
-Base.similar(Ψ::GateState) = GateState(similar(Ψ.U))
-Base.copyto!(Ψ::GateState, ϕ::GateState) = (copyto!(Ψ.U, ϕ.U); Ψ)
-Base.:*(c::Number, Ψ::GateState) = GateState(c * Ψ.U)
-Base.:-(Ψ::GateState, ϕ::GateState) = GateState(Ψ.U - ϕ.U)
-LinearAlgebra.norm(Ψ::GateState) = norm(Ψ.U)
+struct LastSlotState <: AbstractGateState
+    U::Matrix{ComplexF64}
+end
+
+supports_inplace(::Type{<:AbstractGateState}) = true
+Base.copy(Ψ::T) where {T<:AbstractGateState} = T(copy(Ψ.U))
+Base.similar(Ψ::T) where {T<:AbstractGateState} = T(similar(Ψ.U))
+Base.copyto!(Ψ::AbstractGateState, ϕ::AbstractGateState) = (copyto!(Ψ.U, ϕ.U); Ψ)
+Base.:*(c::Number, Ψ::T) where {T<:AbstractGateState} = T(c * Ψ.U)
+Base.:-(Ψ::T, ϕ::AbstractGateState) where {T<:AbstractGateState} = T(Ψ.U - ϕ.U)
+LinearAlgebra.norm(Ψ::AbstractGateState) = norm(Ψ.U)
 
 
 # An immutable state that is not a `StaticArray`: `supports_inplace` is
@@ -47,16 +54,25 @@ Base.:-(Ψ::FrozenState, ϕ::FrozenState) = FrozenState(Ψ.v - ϕ.v)
 LinearAlgebra.norm(Ψ::FrozenState) = norm(Ψ.v)
 
 
-# A deliberately broken storage: it keeps a *reference* to the written data.
-# This is the bug that `check_storage` must detect.
+# Deliberately broken storages that keep a *reference* to the written data,
+# either in every slot or only in the last one. These are the bugs that
+# `check_storage` must detect.
 struct AliasingStorage{T}
     data::Vector{T}
+    last_slot_only::Bool
 end
 
 Storage.init_storage(Ψ::GateState, nt::Integer) =
-    AliasingStorage(Vector{GateState}(undef, nt))
-Storage.write_to_storage!(storage::AliasingStorage, i::Integer, data) =
-    (storage.data[i] = data; storage)  # BUG: no copy
+    AliasingStorage(Vector{GateState}(undef, nt), false)
+Storage.init_storage(Ψ::LastSlotState, nt::Integer) =
+    AliasingStorage(Vector{LastSlotState}(undef, nt), true)
+
+function Storage.write_to_storage!(storage::AliasingStorage, i::Integer, data)
+    aliased = storage.last_slot_only ? (i == length(storage.data)) : true
+    storage.data[i] = aliased ? data : copy(data)  # BUG: no copy
+    return storage
+end
+
 Storage.get_from_storage(storage::AliasingStorage, i) = storage.data[i]
 Storage.get_from_storage!(data, storage::AliasingStorage, i) =
     copyto!(data, storage.data[i])
@@ -71,12 +87,12 @@ quiet_check(args...; kwargs...) =
 @testset "Ownership of stored data" begin
 
     # The contract violation from #119, in isolation
-    Û = ComplexF64[1 0; 0 1]
-    storage = init_storage(Û, 3)
-    write_to_storage!(storage, 1, Û)
-    lmul!(2.0, Û)
+    U = ComplexF64[1 0; 0 1]
+    storage = init_storage(U, 3)
+    write_to_storage!(storage, 1, U)
+    lmul!(2.0, U)
     @test get_from_storage(storage, 1) == ComplexF64[1 0; 0 1]
-    @test get_from_storage(storage, 1) ≢ Û
+    @test get_from_storage(storage, 1) ≢ U
 
     # A `Vector` state goes into a `Matrix` storage, which always copies
     Ψ = ComplexF64[1, 0]
@@ -99,16 +115,30 @@ quiet_check(args...; kwargs...) =
     @test get_from_storage(storage, 1).v == Ψ.v
 
     # Writing to one slot must not disturb another
-    Û = ComplexF64[1 0; 0 1]
-    storage = init_storage(Û, 3)
-    write_to_storage!(storage, 1, Û)
-    lmul!(2.0, Û)
-    write_to_storage!(storage, 2, Û)
+    U = ComplexF64[1 0; 0 1]
+    storage = init_storage(U, 3)
+    write_to_storage!(storage, 1, U)
+    lmul!(2.0, U)
+    write_to_storage!(storage, 2, U)
     @test get_from_storage(storage, 1) == ComplexF64[1 0; 0 1]
     @test get_from_storage(storage, 2) == ComplexF64[2 0; 0 2]
 
+    # `Matrix` storage with a mutable element type must own the elements, not
+    # just the column. `data` here is what several uniform observables produce.
+    buf = [1.0, 2.0]
+    data = [buf, [3.0, 4.0]]
+    storage = init_storage(data, 3)
+    @test storage isa Matrix{Vector{Float64}}
+    write_to_storage!(storage, 1, data)
+    buf[1] = 99.0
+    write_to_storage!(storage, 2, data)
+    @test get_from_storage(storage, 1)[1] == [1.0, 2.0]
+    @test get_from_storage(storage, 2)[1] == [99.0, 2.0]
+    @test get_from_storage(storage, 1)[1] ≢ get_from_storage(storage, 2)[1]
+
     # `write_to_storage!` returns the storage
-    @test write_to_storage!(storage, 3, Û) ≡ storage
+    storage = init_storage(U, 3)
+    @test write_to_storage!(storage, 1, U) ≡ storage
     storage = init_storage(ComplexF64[1, 0], 3)
     @test write_to_storage!(storage, 1, ComplexF64[1, 0]) ≡ storage
 
@@ -122,18 +152,18 @@ end
     Ψ = random_state_vector(4; rng = StableRNG(2821563937))
     @test check_storage(Ψ, tlist; rng = StableRNG(610341865))
 
-    Û = random_matrix(4; rng = StableRNG(1671185571))
-    @test check_storage(Û, tlist; rng = StableRNG(1321808964))
+    U = random_matrix(4; rng = StableRNG(1671185571))
+    @test check_storage(U, tlist; rng = StableRNG(1321808964))
 
     @test check_storage(SVector{4}(Ψ), tlist; rng = StableRNG(3722552871))
-    @test check_storage(SMatrix{4,4}(Û), tlist; rng = StableRNG(2428674146))
+    @test check_storage(SMatrix{4,4}(U), tlist; rng = StableRNG(2428674146))
 
     @test check_storage(FrozenState(Ψ), tlist; rng = StableRNG(3139269722))
 
     # `nt` must not matter: with a long time grid, no slot may drift below
     # `atol` and thus become effectively unchecked
     @test check_storage(
-        Û,
+        U,
         collect(range(0, 10; length = 1000));
         rng = StableRNG(3688239531)
     )
@@ -156,6 +186,10 @@ end
     @test c.value ≡ false
     @test contains(c.output, "the storage must own its data")
 
+    # A storage that aliases only the *final* slot must be rejected as well
+    Ψ = LastSlotState(random_matrix(4; rng = StableRNG(1671185571)))
+    @test !quiet_check(Ψ, tlist; rng = StableRNG(1321808964))
+
 end
 
 
@@ -163,23 +197,36 @@ end
 
     tlist = collect(range(0, 10; length = 10))
     Ψ = random_state_vector(4; rng = StableRNG(2821563937))
-    Ô₁ = random_matrix(4; hermitian = true, rng = StableRNG(610341865))
-    Ô₂ = random_matrix(4; hermitian = true, rng = StableRNG(1671185571))
+    O₁ = random_matrix(4; hermitian = true, rng = StableRNG(610341865))
+    O₂ = random_matrix(4; hermitian = true, rng = StableRNG(1671185571))
 
     # a number
-    @test check_storage(Ψ, tlist, (Ψ -> dot(Ψ, Ô₁, Ψ),); rng = StableRNG(1321808964))
+    @test check_storage(Ψ, tlist, (Ψ -> dot(Ψ, O₁, Ψ),); rng = StableRNG(1321808964))
     # a matrix observable (expectation value via three-argument `dot`)
-    @test check_storage(Ψ, tlist, (Ô₁,); rng = StableRNG(3722552871))
+    @test check_storage(Ψ, tlist, (O₁,); rng = StableRNG(3722552871))
     # a vector (e.g., populations)
     @test check_storage(Ψ, tlist, (Ψ -> abs.(Ψ) .^ 2,); rng = StableRNG(2428674146))
     # uniform multiple observables (stored as the columns of a matrix)
-    @test check_storage(Ψ, tlist, (Ô₁, Ô₂); rng = StableRNG(3139269722))
+    @test check_storage(Ψ, tlist, (O₁, O₂); rng = StableRNG(3139269722))
     # non-uniform multiple observables (stored as a vector of tuples)
-    observables = (Ψ -> real(dot(Ψ, Ô₁, Ψ)), Ψ -> count(abs.(Ψ) .^ 2 .> 0.1))
+    observables = (Ψ -> real(dot(Ψ, O₁, Ψ)), Ψ -> count(abs.(Ψ) .^ 2 .> 0.1))
     @test check_storage(Ψ, tlist, observables; rng = StableRNG(3688239531))
     # a tuple containing mutable data
     observables = (Ψ -> abs.(Ψ) .^ 2, Ψ -> count(abs.(Ψ) .^ 2 .> 0.1))
     @test check_storage(Ψ, tlist, observables; rng = StableRNG(2821563937))
+    # uniform observables that reuse a preallocated buffer: these land in a
+    # `Matrix{Vector{Float64}}` storage, whose elements must be owned
+    buf1 = zeros(Float64, 4)
+    buf2 = zeros(Float64, 4)
+    observables = (Ψ -> (buf1 .= abs.(Ψ) .^ 2; buf1), Ψ -> (buf2 .= real.(Ψ); buf2))
+    @test check_storage(Ψ, tlist, observables; rng = StableRNG(610341865))
+    storage = init_storage(Ψ, tlist, observables)
+    @test storage isa Matrix{Vector{Float64}}
+    for (n, c) in enumerate([1.0, 2.0, 3.0])
+        write_to_storage!(storage, n, map_observables(observables, tlist, n, c * Ψ))
+    end
+    @test get_from_storage(storage, 1)[1] ≢ get_from_storage(storage, 3)[1]
+    @test get_from_storage(storage, 1)[1] ≈ abs.(Ψ) .^ 2
 
     # the state itself: the `_StoreState` path used by `propagate`
     @test check_storage(
@@ -188,9 +235,9 @@ end
         QuantumPropagators._StoreState();
         rng = StableRNG(610341865)
     )
-    Û = random_matrix(4; rng = StableRNG(1671185571))
+    U = random_matrix(4; rng = StableRNG(1671185571))
     @test check_storage(
-        Û,
+        U,
         tlist,
         QuantumPropagators._StoreState();
         rng = StableRNG(1321808964)
@@ -221,14 +268,14 @@ end
     MHz = 0.001GHz
     ns = 1.0
 
-    Û₀ = Matrix{ComplexF64}(I(4)) / 2
+    U₀ = Matrix{ComplexF64}(I(4)) / 2
 
-    Ĥ = let δ₁ = 100MHz, δ₂ = -100MHz, J = 3MHz, Ω₀ = 35MHz
+    H = let δ₁ = 100MHz, δ₂ = -100MHz, J = 3MHz, Ω₀ = 35MHz
         Matrix{ComplexF64}([
-                0 Ω₀/2 Ω₀/2 0
-                Ω₀/2 δ₂ J Ω₀/2
-                Ω₀/2 J δ₁ Ω₀/2
-                0 Ω₀/2 Ω₀/2 δ₁+δ₂
+                  0    Ω₀/2    Ω₀/2     0
+                Ω₀/2    δ₂      J     Ω₀/2
+                Ω₀/2    J       δ₁    Ω₀/2
+                  0    Ω₀/2    Ω₀/2   δ₁+δ₂
             ])
     end
 
@@ -236,10 +283,10 @@ end
     tlist = collect(range(0, T, step = 0.1ns))
     nt = length(tlist)
 
-    propagator = init_prop(Û₀, Ĥ, tlist; method = Cheby)
-    storage = init_storage(Û₀, tlist)
-    expected = [copy(Û₀)]
-    write_to_storage!(storage, 1, Û₀)
+    propagator = init_prop(U₀, H, tlist; method = Cheby)
+    storage = init_storage(U₀, tlist)
+    expected = [copy(U₀)]
+    write_to_storage!(storage, 1, U₀)
     for n = 1:(nt-1)
         state = prop_step!(propagator)
         write_to_storage!(storage, n + 1, state)
@@ -252,10 +299,10 @@ end
     @test get_from_storage(storage, nt) ≢ get_from_storage(storage, nt - 1)
     @test norm(get_from_storage(storage, nt) - get_from_storage(storage, nt - 1)) > 1e-3
     @test norm(get_from_storage(storage, nt) - get_from_storage(storage, 1)) > 0.1
-    @test get_from_storage(storage, 1) ≈ Û₀
+    @test get_from_storage(storage, 1) ≈ U₀
 
     # The same via `propagate`
-    storage = propagate(Û₀, Ĥ, tlist; method = Cheby, storage = true)
+    storage = propagate(U₀, H, tlist; method = Cheby, storage = true)
     @test size(storage) == (nt,)
     @test all(storage[n] ≈ expected[n] for n = 1:nt)
     @test storage[nt] ≢ storage[nt-1]

--- a/test/test_storage.jl
+++ b/test/test_storage.jl
@@ -1,0 +1,264 @@
+# SPDX-FileCopyrightText: © 2021 Michael Goerz <mail@michaelgoerz.net>
+#
+# SPDX-License-Identifier: MIT
+
+using Test
+using Logging: with_logger, NullLogger
+using LinearAlgebra: LinearAlgebra, I, norm, dot, lmul!
+using StableRNGs: StableRNG
+using IOCapture: IOCapture
+using StaticArrays: SVector, SMatrix
+using QuantumControlTestUtils.RandomObjects: random_state_vector, random_matrix
+
+using QuantumPropagators: QuantumPropagators, Cheby, init_prop, prop_step!, propagate
+using QuantumPropagators.Storage:
+    init_storage, write_to_storage!, get_from_storage, get_from_storage!, map_observables
+using QuantumPropagators.Interfaces: check_storage
+import QuantumPropagators.Interfaces: supports_inplace
+import QuantumPropagators.Storage
+
+
+# A state that wraps a `Matrix`, to exercise the generic `Vector`-of-states
+# storage path with a type that is not an `AbstractArray`.
+struct GateState
+    U::Matrix{ComplexF64}
+end
+
+supports_inplace(::Type{GateState}) = true
+Base.copy(Ψ::GateState) = GateState(copy(Ψ.U))
+Base.similar(Ψ::GateState) = GateState(similar(Ψ.U))
+Base.copyto!(Ψ::GateState, ϕ::GateState) = (copyto!(Ψ.U, ϕ.U); Ψ)
+Base.:*(c::Number, Ψ::GateState) = GateState(c * Ψ.U)
+Base.:-(Ψ::GateState, ϕ::GateState) = GateState(Ψ.U - ϕ.U)
+LinearAlgebra.norm(Ψ::GateState) = norm(Ψ.U)
+
+
+# An immutable state that is not a `StaticArray`: `supports_inplace` is
+# `false`, but the object is not `isbits` either, so the storage must still
+# take a copy.
+struct FrozenState
+    v::Vector{ComplexF64}
+end
+
+supports_inplace(::Type{FrozenState}) = false
+Base.copy(Ψ::FrozenState) = FrozenState(copy(Ψ.v))
+Base.:*(c::Number, Ψ::FrozenState) = FrozenState(c * Ψ.v)
+Base.:-(Ψ::FrozenState, ϕ::FrozenState) = FrozenState(Ψ.v - ϕ.v)
+LinearAlgebra.norm(Ψ::FrozenState) = norm(Ψ.v)
+
+
+# A deliberately broken storage: it keeps a *reference* to the written data.
+# This is the bug that `check_storage` must detect.
+struct AliasingStorage{T}
+    data::Vector{T}
+end
+
+Storage.init_storage(Ψ::GateState, nt::Integer) =
+    AliasingStorage(Vector{GateState}(undef, nt))
+Storage.write_to_storage!(storage::AliasingStorage, i::Integer, data) =
+    (storage.data[i] = data; storage)  # BUG: no copy
+Storage.get_from_storage(storage::AliasingStorage, i) = storage.data[i]
+Storage.get_from_storage!(data, storage::AliasingStorage, i) =
+    copyto!(data, storage.data[i])
+
+
+quiet_check(args...; kwargs...) =
+    with_logger(NullLogger()) do
+        check_storage(args...; kwargs..., quiet = true)
+    end
+
+
+@testset "Ownership of stored data" begin
+
+    # The contract violation from #119, in isolation
+    Û = ComplexF64[1 0; 0 1]
+    storage = init_storage(Û, 3)
+    write_to_storage!(storage, 1, Û)
+    lmul!(2.0, Û)
+    @test get_from_storage(storage, 1) == ComplexF64[1 0; 0 1]
+    @test get_from_storage(storage, 1) ≢ Û
+
+    # A `Vector` state goes into a `Matrix` storage, which always copies
+    Ψ = ComplexF64[1, 0]
+    storage = init_storage(Ψ, 3)
+    write_to_storage!(storage, 1, Ψ)
+    lmul!(2.0, Ψ)
+    @test get_from_storage(storage, 1) == ComplexF64[1, 0]
+
+    # Immutable `isbits` data is stored by reference (no copy)
+    Ψ = SVector{2}(ComplexF64[1, 0])
+    storage = init_storage(Ψ, 3)
+    write_to_storage!(storage, 1, Ψ)
+    @test get_from_storage(storage, 1) === Ψ
+
+    # A non-`isbits` immutable wrapper is *not* provably safe, so it is copied
+    Ψ = FrozenState(ComplexF64[1, 0])
+    storage = init_storage(Ψ, 3)
+    write_to_storage!(storage, 1, Ψ)
+    @test get_from_storage(storage, 1) ≢ Ψ
+    @test get_from_storage(storage, 1).v == Ψ.v
+
+    # Writing to one slot must not disturb another
+    Û = ComplexF64[1 0; 0 1]
+    storage = init_storage(Û, 3)
+    write_to_storage!(storage, 1, Û)
+    lmul!(2.0, Û)
+    write_to_storage!(storage, 2, Û)
+    @test get_from_storage(storage, 1) == ComplexF64[1 0; 0 1]
+    @test get_from_storage(storage, 2) == ComplexF64[2 0; 0 2]
+
+    # `write_to_storage!` returns the storage
+    @test write_to_storage!(storage, 3, Û) ≡ storage
+    storage = init_storage(ComplexF64[1, 0], 3)
+    @test write_to_storage!(storage, 1, ComplexF64[1, 0]) ≡ storage
+
+end
+
+
+@testset "check_storage for states" begin
+
+    tlist = collect(range(0, 10; length = 10))
+
+    Ψ = random_state_vector(4; rng = StableRNG(2821563937))
+    @test check_storage(Ψ, tlist; rng = StableRNG(610341865))
+
+    Û = random_matrix(4; rng = StableRNG(1671185571))
+    @test check_storage(Û, tlist; rng = StableRNG(1321808964))
+
+    @test check_storage(SVector{4}(Ψ), tlist; rng = StableRNG(3722552871))
+    @test check_storage(SMatrix{4,4}(Û), tlist; rng = StableRNG(2428674146))
+
+    @test check_storage(FrozenState(Ψ), tlist; rng = StableRNG(3139269722))
+
+    # `nt` must not matter: with a long time grid, no slot may drift below
+    # `atol` and thus become effectively unchecked
+    @test check_storage(
+        Û,
+        collect(range(0, 10; length = 1000));
+        rng = StableRNG(3688239531)
+    )
+
+end
+
+
+@testset "check_storage detects a reference-storing implementation" begin
+
+    tlist = collect(range(0, 10; length = 10))
+    Ψ = GateState(random_matrix(4; rng = StableRNG(2821563937)))
+
+    # `AliasingStorage` stores a reference, which the ownership loop detects
+    @test !quiet_check(Ψ, tlist; rng = StableRNG(610341865))
+
+    # The failure is reported
+    c = IOCapture.capture(rethrow = Union{}) do
+        check_storage(Ψ, tlist; rng = StableRNG(610341865))
+    end
+    @test c.value ≡ false
+    @test contains(c.output, "the storage must own its data")
+
+end
+
+
+@testset "check_storage for observables" begin
+
+    tlist = collect(range(0, 10; length = 10))
+    Ψ = random_state_vector(4; rng = StableRNG(2821563937))
+    Ô₁ = random_matrix(4; hermitian = true, rng = StableRNG(610341865))
+    Ô₂ = random_matrix(4; hermitian = true, rng = StableRNG(1671185571))
+
+    # a number
+    @test check_storage(Ψ, tlist, (Ψ -> dot(Ψ, Ô₁, Ψ),); rng = StableRNG(1321808964))
+    # a matrix observable (expectation value via three-argument `dot`)
+    @test check_storage(Ψ, tlist, (Ô₁,); rng = StableRNG(3722552871))
+    # a vector (e.g., populations)
+    @test check_storage(Ψ, tlist, (Ψ -> abs.(Ψ) .^ 2,); rng = StableRNG(2428674146))
+    # uniform multiple observables (stored as the columns of a matrix)
+    @test check_storage(Ψ, tlist, (Ô₁, Ô₂); rng = StableRNG(3139269722))
+    # non-uniform multiple observables (stored as a vector of tuples)
+    observables = (Ψ -> real(dot(Ψ, Ô₁, Ψ)), Ψ -> count(abs.(Ψ) .^ 2 .> 0.1))
+    @test check_storage(Ψ, tlist, observables; rng = StableRNG(3688239531))
+    # a tuple containing mutable data
+    observables = (Ψ -> abs.(Ψ) .^ 2, Ψ -> count(abs.(Ψ) .^ 2 .> 0.1))
+    @test check_storage(Ψ, tlist, observables; rng = StableRNG(2821563937))
+
+    # the state itself: the `_StoreState` path used by `propagate`
+    @test check_storage(
+        Ψ,
+        tlist,
+        QuantumPropagators._StoreState();
+        rng = StableRNG(610341865)
+    )
+    Û = random_matrix(4; rng = StableRNG(1671185571))
+    @test check_storage(
+        Û,
+        tlist,
+        QuantumPropagators._StoreState();
+        rng = StableRNG(1321808964)
+    )
+
+end
+
+
+@testset "check_storage for plain data" begin
+
+    @test check_storage(1.0, 10; transform = (x -> 0.9x))
+    @test check_storage(1.0 + 0.5im, 10; transform = (x -> 0.9x))
+    @test check_storage(ComplexF64[1, 2, 3], 10; transform = (v -> 0.9v))
+    @test check_storage((1.0, 2), 10; transform = (t -> (0.9t[1], t[2] + 1)))
+
+    # An in-place `transform` on mutable non-`Vector` data exercises ownership
+    # in the generic `Vector`-of-data storage path
+    M = ComplexF64[1 0; 0 1]
+    @test check_storage(M, 10; transform = (M -> (lmul!(0.9, M); M)))
+
+end
+
+
+@testset "Storing the states of an in-place propagation (#119)" begin
+
+    # The MWE from https://github.com/JuliaQuantumControl/QuantumPropagators.jl/issues/119
+    GHz = 1.0
+    MHz = 0.001GHz
+    ns = 1.0
+
+    Û₀ = Matrix{ComplexF64}(I(4)) / 2
+
+    Ĥ = let δ₁ = 100MHz, δ₂ = -100MHz, J = 3MHz, Ω₀ = 35MHz
+        Matrix{ComplexF64}([
+                0 Ω₀/2 Ω₀/2 0
+                Ω₀/2 δ₂ J Ω₀/2
+                Ω₀/2 J δ₁ Ω₀/2
+                0 Ω₀/2 Ω₀/2 δ₁+δ₂
+            ])
+    end
+
+    T = 400ns
+    tlist = collect(range(0, T, step = 0.1ns))
+    nt = length(tlist)
+
+    propagator = init_prop(Û₀, Ĥ, tlist; method = Cheby)
+    storage = init_storage(Û₀, tlist)
+    expected = [copy(Û₀)]
+    write_to_storage!(storage, 1, Û₀)
+    for n = 1:(nt-1)
+        state = prop_step!(propagator)
+        write_to_storage!(storage, n + 1, state)
+        push!(expected, copy(state))
+    end
+
+    # Every slot must hold the state as of the time it was written
+    @test all(get_from_storage(storage, n) ≈ expected[n] for n = 1:nt)
+    # Consecutive stored states must be distinct objects with different values
+    @test get_from_storage(storage, nt) ≢ get_from_storage(storage, nt - 1)
+    @test norm(get_from_storage(storage, nt) - get_from_storage(storage, nt - 1)) > 1e-3
+    @test norm(get_from_storage(storage, nt) - get_from_storage(storage, 1)) > 0.1
+    @test get_from_storage(storage, 1) ≈ Û₀
+
+    # The same via `propagate`
+    storage = propagate(Û₀, Ĥ, tlist; method = Cheby, storage = true)
+    @test size(storage) == (nt,)
+    @test all(storage[n] ≈ expected[n] for n = 1:nt)
+    @test storage[nt] ≢ storage[nt-1]
+    @test norm(storage[nt] - storage[nt-1]) > 1e-3
+
+end


### PR DESCRIPTION

The generic `write_to_storage!` stored a reference, so that for any mutable data not covered by a copying specialization, the stored value silently changed when the caller mutated the object after the write. Storing the state of an in-place propagation at every time step left all slots aliasing the propagator's single buffer.

### What changed

`write_to_storage!` now stores a copy, skipped only for data whose type proves the contract holds regardless, i.e. immutable values (`isbits`): numbers, tuples of numbers, `SVector` and `SMatrix` of bits elements keep their zero-copy behavior. This is a single method rather than the two sketched in the issue: `isbits(data)` subsumes the `isbitstype(T)` test on the storage element type (the branch is constant-folded), and the same method covers data whose type does not match the storage element type. Tuples and named tuples take the copy element-wise, because `copy` is not defined for them.

With ownership living in `write_to_storage!`, the copy in `map_observables(::_StoreState, ...)` is dropped, along with the `state::Vector` specialization that existed only to coordinate with the copying `Matrix`-storage write. Exactly one copy now happens per stored value, so there is no added cost on any path that was already correct.

A new "The storage contract" section in the documentation states the round-trip, ownership, and read-only guarantees; the docstrings link to it.

### `QuantumPropagators.Interfaces.check_storage`

New interface check, with methods matching those of `init_storage`:

```julia
@test check_storage(state, tlist; rng=Random.default_rng(), atol=1e-14, quiet=false)
@test check_storage(state, tlist, observables; rng=Random.default_rng(), atol=1e-14, quiet=false)
@test check_storage(data, nt; transform=(data -> data), atol=1e-14, quiet=false)
```

The state-based forms fill every slot from a fresh object and read all of them back, then, if `supports_inplace(state)`, fill every slot from a single object mutated in place between the writes and compare against copies recorded at write time. The second loop checks reference storage. Each written value is derived from the original state with a factor in `[0.5, 1.5)`.

### Tests

New `test/test_storage.jl` covers the isolated ownership demonstration, slot independence, `check_storage` across `Vector`, `Matrix`, `SVector`, `SMatrix` and a non-`SArray` immutable state, across observables returning numbers, vectors, uniform and mixed tuples, and the state itself, a deliberately reference-storing `AliasingStorage` that `check_storage` must reject, and the propagation MWE as a regression test. Reverting the fix makes `check_storage(::Matrix, tlist)` return `false`, while the `Vector`-state path, which was never broken, stays `true`.

One deviation from the issue: its MWE asserted that consecutive stored states differ by more than `1e-2`, but at `dt = 0.1ns` they actually differ by `0.0075`. That threshold is `1e-3` here, and the assertion it stood in for is made directly by comparing every slot against an independently kept copy of the state at that step.

Closes #119.