### PR TITLE
Fix interface checks that relied on uninitialized memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Also see the [GitHub Releases](https://github.com/JuliaQuantumControl/QuantumPro
 
 * Added: `QuantumPropagators.Interfaces.check_storage`, which verifies that a storage implementation fulfills the storage contract [[#119], [#120]]
 * Fixed: `write_to_storage!` now stores a copy of any mutable data, so that the storage owns its data. Previously, storing the state of an in-place propagation at every time step could leave all slots aliasing a single buffer [[#119], [#120]]
+* Fixed: `check_state` now reliably detects a `copyto!` that does not overwrite its destination, and `check_operator` a `mul!` that does not write its result. Both checks previously read uninitialized memory and could pass silently
 
 ## [v0.9.0] — 2026-06-15
 

--- a/src/interfaces/operator.jl
+++ b/src/interfaces/operator.jl
@@ -189,12 +189,17 @@ function check_operator(
     if supports_inplace(state)
 
         try
-            ϕ = similar(Ψ)
+            χ = op * Ψ
+            # `ϕ` must start out different from `χ` (instead of being the
+            # uninitialized `similar(Ψ)`), so that a `mul!` which fails to write
+            # is detected. A zeroed `ϕ` serves for that, except when `op`
+            # annihilates `Ψ`, as for a lowering operator and the ground state.
+            ϕ = (norm(χ) > atol) ? 0.0 * Ψ : copy(Ψ)
             if mul!(ϕ, op, Ψ) ≢ ϕ
                 quiet || @error "$(px)`mul!(ϕ, op, state)` must return the resulting ϕ"
                 success = false
             end
-            Δ = norm(ϕ - op * Ψ)
+            Δ = norm(ϕ - χ)
             if Δ > atol
                 quiet || @error "$(px)`mul!(ϕ, op, state)` must match `op * state`" Δ atol
                 success = false
@@ -249,7 +254,8 @@ function check_operator(
                 success = false
             end
             if supports_inplace(state)
-                ϕ = similar(Ψ)
+                # see the 3-argument `mul!` check above for the choice of `ϕ`
+                ϕ = (norm(op * Ψ) > atol) ? 0.0 * Ψ : copy(Ψ)
                 mul!(ϕ, op, Ψ)
                 Δ = abs(dot(Ψ, op, Ψ) - dot(Ψ, ϕ))
                 if Δ > atol

--- a/src/interfaces/propagator.jl
+++ b/src/interfaces/propagator.jl
@@ -152,7 +152,9 @@ function check_propagator(
 
     Ψ₀_ref = state
     Ψ₀ = copy(state)
-    Ψ₁ = similar(Ψ₀)
+    # `copy`, not `similar`: `Ψ₁` is compared against `propagator.state` further
+    # below, and keeps this initial value if `prop_step!` throws
+    Ψ₁ = copy(Ψ₀)
 
     try
         Ψ₁ = prop_step!(propagator)

--- a/src/interfaces/state.jl
+++ b/src/interfaces/state.jl
@@ -43,7 +43,8 @@ following:
 
 * `similar(state)` must be defined and return a valid state of the same type as
   the original `state`
-* `copyto!(other, state)` must be defined
+* `copyto!(other, state)` must be defined and must overwrite the data of
+  `other`, so that `other` and `state` compare equal afterwards
 * `fill!(state, c)` must be defined
 * `LinearAlgebra.lmul!(c, state)` for a scalar `c` must be defined
 * `LinearAlgebra.axpy!(c, state, other)` must be defined
@@ -240,6 +241,7 @@ function check_state(
 
         has_similar = true
         similar_is_valid = true
+        copyto_is_valid = true
         try
             ϕ = similar(state)
             if typeof(ϕ) != typeof(state)
@@ -256,9 +258,39 @@ function check_state(
             success = false
         end
 
+        # `fill!` is checked before `copyto!`, on a `copy` of the state, so that
+        # the `copyto!` check below can use it to zero out the uninitialized
+        # data from `similar`
+        has_fill = true
+        try
+            χ = copy(state)
+            ϕ = fill!(χ, 0.0)
+            if !isa(ϕ, typeof(χ))
+                quiet || @error "$(px)`fill!(state, 0.0)` must return the filled state"
+                success = false
+            end
+            Δ = norm(ϕ)
+            if Δ > atol
+                quiet || @error "$(px)`fill!(state, 0.0)` must have norm 0" Δ atol
+                success = false
+            end
+        catch exc
+            quiet || @error(
+                "$(px)`fill!(state, c)` must be defined.",
+                exception = (exc, catch_abbreviated_backtrace())
+            )
+            has_fill = false
+            success = false
+        end
+
         try
             if has_similar
                 ϕ = similar(state)
+                # Zeroing `ϕ` ensures it differs from `state`, so that a
+                # `copyto!` that does not write is detected. Otherwise, the
+                # uninitialized data from `similar` might match `state` by
+                # accident.
+                has_fill && fill!(ϕ, 0.0)
                 copyto!(ϕ, state)
                 if _check_similar
                     # we only check ϕ after `copyto!`, because just `similar`
@@ -281,6 +313,7 @@ function check_state(
                 if Δ > atol
                     quiet ||
                         @error "$(px)`ϕ - state` must have norm 0, where `ϕ = similar(state); copyto!(ϕ, state)`" Δ atol
+                    copyto_is_valid = false
                     success = false
                 end
             end
@@ -289,34 +322,12 @@ function check_state(
                 "$(px)`copyto!(other, state)` must be defined.",
                 exception = (exc, catch_abbreviated_backtrace())
             )
+            copyto_is_valid = false
             success = false
         end
 
         try
-            if has_similar && similar_is_valid
-                ϕ = similar(state)
-                copyto!(ϕ, state)
-                state_zero = fill!(ϕ, 0.0)
-                if !isa(state_zero, typeof(ϕ))
-                    quiet || @error "$(px)`fill!(state, 0.0)` must return the filled state"
-                    success = false
-                end
-                Δ = norm(state_zero)
-                if Δ > atol
-                    quiet || @error "$(px)`fill!(state, 0.0)` must have norm 0" Δ atol
-                    success = false
-                end
-            end
-        catch exc
-            quiet || @error(
-                "$(px)`fill!(state, c)` must be defined.",
-                exception = (exc, catch_abbreviated_backtrace())
-            )
-            success = false
-        end
-
-        try
-            if has_similar && similar_is_valid
+            if has_similar && similar_is_valid && copyto_is_valid
                 ϕ = similar(state)
                 copyto!(ϕ, state)
                 ϕ = lmul!(1im, ϕ)
@@ -336,7 +347,7 @@ function check_state(
         end
 
         try
-            if has_similar && similar_is_valid
+            if has_similar && similar_is_valid && copyto_is_valid
                 ϕ = similar(state)
                 copyto!(ϕ, state)
                 ϕ = lmul!(0.0, ϕ)
@@ -356,7 +367,7 @@ function check_state(
         end
 
         try
-            if has_similar && similar_is_valid
+            if has_similar && similar_is_valid && copyto_is_valid
                 ϕ = similar(state)
                 copyto!(ϕ, state)
                 ϕ = axpy!(1im, state, ϕ)

--- a/src/interfaces/storage.jl
+++ b/src/interfaces/storage.jl
@@ -190,7 +190,11 @@ function check_storage(
         end
         if ok  # also check in-place extraction
             try
-                state = similar(state_initial)
+                # A zeroed state (instead of the uninitialized
+                # `similar(state_initial)`) ensures that a
+                # `get_from_storage!` which fails to write is detected: every
+                # `expected` value is a non-zero multiple of `state_initial`
+                state = 0.0 * state_initial
                 for n = 1:nt
                     get_from_storage!(state, storage, n)
                     delta = _storage_mismatch(state, expected[n])

--- a/test/test_invalid_interfaces.jl
+++ b/test/test_invalid_interfaces.jl
@@ -226,6 +226,48 @@ end
 end
 
 
+@testset "Invalid operator with non-writing mul!" begin
+
+    # Operator whose 3-argument `mul!` writes nothing, checked against a state
+    # that the operator annihilates (a lowering operator and the ground state).
+    # The destination `ϕ` must not be seeded with the expected result, or the
+    # broken `mul!` goes unnoticed.
+    A = ComplexF64[0 1 0 0; 0 0 sqrt(2) 0; 0 0 0 sqrt(3); 0 0 0 0]
+
+    struct NonWritingMulOp end
+    QuantumPropagators.Interfaces.supports_inplace(::Type{NonWritingMulOp}) = true
+    Base.size(::NonWritingMulOp) = (4, 4)
+    Base.size(::NonWritingMulOp, d::Int) = 4
+    Base.eltype(::Type{NonWritingMulOp}) = ComplexF64
+    QuantumPropagators.Controls.get_controls(::NonWritingMulOp) = ()
+    QuantumPropagators.Controls.evaluate(op::NonWritingMulOp, args...; kwargs...) = op
+    Base.:(*)(::NonWritingMulOp, Ψ) = A * Ψ
+    LinearAlgebra.mul!(ϕ, ::NonWritingMulOp, Ψ) = ϕ  # doesn't write!
+    LinearAlgebra.mul!(ϕ, ::NonWritingMulOp, Ψ, α, β) = (lmul!(β, ϕ); axpy!(α, A * Ψ, ϕ))
+    LinearAlgebra.dot(a, ::NonWritingMulOp, b) = dot(a, A * b)
+
+    tlist = collect(range(0, 10, length = 101))
+    operator = NonWritingMulOp()
+
+    # `A * state ≡ 0`, so a zero-seeded `ϕ` would match the expected result
+    state = ComplexF64[1, 0, 0, 0]
+    captured = IOCapture.capture() do
+        check_operator(operator; state, tlist)
+    end
+    @test captured.value ≡ false
+    @test contains(captured.output, "`mul!(ϕ, op, state)` must match `op * state`")
+
+    # A state that the operator does not annihilate
+    state = ComplexF64[0, 1, 0, 0]
+    captured = IOCapture.capture() do
+        check_operator(operator; state, tlist)
+    end
+    @test captured.value ≡ false
+    @test contains(captured.output, "`mul!(ϕ, op, state)` must match `op * state`")
+
+end
+
+
 @testset "Invalid operator with wrong returns" begin
 
     # Operator where `*` returns wrong type, `mul!` returns wrong reference,
@@ -932,7 +974,14 @@ end
 
 @testset "Invalid state with unfaithful copyto!" begin
 
-    # State where copyto! doesn't actually copy the data
+    # State where copyto! doesn't actually copy the data.
+    #
+    # `check_state` detects this by zeroing `similar(state)` with `fill!` before
+    # the `copyto!`, so that the uninitialized data cannot match `state` by
+    # accident. Any fixture with a `copyto!` that does not write must therefore
+    # keep `fill!` working: if both are broken, the check silently depends on
+    # whatever `similar` happens to return, which makes the test pass or fail at
+    # random depending on the machine.
     struct BadCopytoState
         data::Vector{ComplexF64}
     end
@@ -952,6 +1001,45 @@ end
         (axpy!(c, a.data, b.data); b)
 
     state = BadCopytoState(ComplexF64[1, 0, 0, 0])
+    captured = IOCapture.capture() do
+        check_state(state; normalized = true)
+    end
+    @test captured.value ≡ false
+    @test contains(
+        captured.output,
+        "must have norm 0, where `ϕ = similar(state); copyto!(ϕ, state)`"
+    )
+
+end
+
+
+@testset "Invalid state with non-writing copyto!" begin
+
+    # State where `copyto!` doesn't write, and `similar` returns memory that
+    # already matches `state`. This is what uninitialized memory from `similar`
+    # may look like by accident, so the check must not depend on it.
+    struct NonWritingCopytoState
+        data::Vector{ComplexF64}
+    end
+    QuantumPropagators.Interfaces.supports_inplace(::Type{NonWritingCopytoState}) = true
+    Base.copy(s::NonWritingCopytoState) = NonWritingCopytoState(copy(s.data))
+    Base.similar(s::NonWritingCopytoState) = NonWritingCopytoState(copy(s.data))
+    Base.copyto!(a::NonWritingCopytoState, b::NonWritingCopytoState) = a  # doesn't write!
+    LinearAlgebra.dot(a::NonWritingCopytoState, b::NonWritingCopytoState) =
+        dot(a.data, b.data)
+    LinearAlgebra.norm(a::NonWritingCopytoState) = norm(a.data)
+    Base.:+(a::NonWritingCopytoState, b::NonWritingCopytoState) =
+        NonWritingCopytoState(a.data + b.data)
+    Base.:-(a::NonWritingCopytoState, b::NonWritingCopytoState) =
+        NonWritingCopytoState(a.data - b.data)
+    Base.:*(α::Number, s::NonWritingCopytoState) = NonWritingCopytoState(α * s.data)
+    Base.zero(s::NonWritingCopytoState) = NonWritingCopytoState(zero(s.data))
+    Base.fill!(s::NonWritingCopytoState, v) = (fill!(s.data, v); s)
+    LinearAlgebra.lmul!(c, s::NonWritingCopytoState) = (lmul!(c, s.data); s)
+    LinearAlgebra.axpy!(c, a::NonWritingCopytoState, b::NonWritingCopytoState) =
+        (axpy!(c, a.data, b.data); b)
+
+    state = NonWritingCopytoState(ComplexF64[1, 0, 0, 0])
     captured = IOCapture.capture() do
         check_state(state; normalized = true)
     end


### PR DESCRIPTION
`check_state` verified `copyto!` by copying `state` into `similar(state)` and comparing the result against `state`. A `copyto!` that writes nothing leaves the uninitialized data from `similar` in place, so the check passed whenever that memory happened to match `state`. This is why the "unfaithful copyto!" test failed on CI but not locally: the allocator had recycled a buffer that still held the state's own data.

The `fill!` check now runs first, on a `copy` of the state so that it needs nothing that is not already verified, and the `copyto!` check zeroes its destination before copying. The outcome no longer depends on what `similar` returns. The `lmul!` and `axpy!` checks need a faithful copy, which a broken `copyto!` cannot provide, so they are gated on `copyto!` having passed.

`check_operator` had the same defect twice: a `mul!` that fails to write its result went unnoticed. Both destinations are now seeded with a value known to differ from `op * state`, which matters when the operator annihilates the state, as for a lowering operator and the ground state. `check_storage` and `check_propagator` had latent instances, now seeded deterministically as well.

New tests cover a `copyto!` and a `mul!` that do not write, with `similar` returning memory that already matches the expected result. The `check_state` docstring now states explicitly that `copyto!` must overwrite its destination.